### PR TITLE
Update Libraries / App version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ apply plugin: 'com.google.protobuf'
 
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "zapsolutions.zap"
         minSdkVersion 21
-        targetSdkVersion 28
-        versionCode 5
-        versionName "0.2.2-alpha"
+        targetSdkVersion 29
+        versionCode 6
+        versionName "0.2.3-alpha"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         setProperty("archivesBaseName", "zap-android-" + versionName)
     }
@@ -106,16 +106,16 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.21.0'
     implementation 'io.grpc:grpc-protobuf-lite:1.21.0'
     implementation 'io.grpc:grpc-stub:1.21.0'
-    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
     compileOnly 'com.google.api.grpc:googleapis-common-protos:0.0.3'
 
     // Used for base encoding and URI escaping
-    implementation 'com.google.guava:guava:27.0.1-android'
+    implementation 'com.google.guava:guava:28.0-android'
 
 
     implementation 'androidx.appcompat:appcompat:1.1.0-beta01'
     implementation 'com.google.android.material:material:1.1.0-alpha07'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.preference:preference:1.1.0-beta01'
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // Needed for gRPC
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.7'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.9'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Jun 29 22:08:57 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- updated zap version for the next release cycle
- increased target Sdk and compile Sdk to 29
- updated gradle and some libraries
- a warning is now shown, this will be fixed in protobuf-gradle-plugin:0.8.10