### PR TITLE
Move scrambled PIN option to advanced options

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
@@ -34,7 +34,7 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 if (mSwScrambledPin.isChecked()) {
                     mUG.securityScrambledPin();
-                    // the value is set from the guardian callback, that's why we don't chang switch state here.
+                    // the value is set from the guardian callback, that's why we don't change switch state here.
                     return false;
                 } else {
                     return true;
@@ -49,7 +49,7 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 if (mSwScreenProtection.isChecked()) {
                     mUG.securityScreenProtection();
-                    // the value is set from the guardian callback, that's why we don't chang switch state here.
+                    // the value is set from the guardian callback, that's why we don't change switch state here.
                     return false;
                 } else {
                     getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);

--- a/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
@@ -16,6 +16,7 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
 
     private static final String LOG_TAG = "Advanced Settings";
     private UserGuardian mUG;
+    private SwitchPreference mSwScrambledPin;
     private SwitchPreference mSwScreenProtection;
 
     @Override
@@ -25,6 +26,21 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
 
         mUG = new UserGuardian(getActivity(), this);
 
+
+        // On change scramble pin option
+        mSwScrambledPin = findPreference("scramblePin");
+        mSwScrambledPin.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (mSwScrambledPin.isChecked()) {
+                    mUG.securityScrambledPin();
+                    // the value is set from the guardian callback, that's why we don't chang switch state here.
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+        });
 
         // On change screen recording option
         mSwScreenProtection = findPreference("preventScreenRecording");
@@ -48,6 +64,9 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
     @Override
     public void guardianDialogConfirmed(String DialogName) {
         switch (DialogName) {
+            case UserGuardian.DISABLE_SCRAMBLED_PIN:
+                mSwScrambledPin.setChecked(false);
+                break;
             case UserGuardian.DISABLE_SCREEN_PROTECTION:
                 mSwScreenProtection.setChecked(false);
                 getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);

--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -44,7 +44,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements UserGu
 
 
     private UserGuardian mUG;
-    private SwitchPreference mSwScrambledPin;
     private SwitchPreference mSwHideTotalBalance;
     private ListPreference mListCurrency;
 
@@ -233,20 +232,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements UserGu
             }
         });
 
-        // On change scramble pin option
-        mSwScrambledPin = findPreference("scramblePin");
-        mSwScrambledPin.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object newValue) {
-                if (mSwScrambledPin.isChecked()) {
-                    mUG.securityScrambledPin();
-                    // the value is set from the guardian callback, that's why we don't chang switch state here.
-                    return false;
-                } else {
-                    return true;
-                }
-            }
-        });
 
         // Action when clicked on "reset security warnings"
         final Preference prefResetGuardian = findPreference("resetGuardian");
@@ -313,11 +298,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements UserGu
 
     @Override
     public void guardianDialogConfirmed(String DialogName) {
-        switch (DialogName) {
-            case UserGuardian.DISABLE_SCRAMBLED_PIN:
-                mSwScrambledPin.setChecked(false);
-                break;
-        }
+
     }
 
     private CharSequence[] joinCharSequenceArrays(CharSequence[] first, CharSequence[] second) {

--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -38,12 +38,10 @@ import zapsolutions.zap.util.Wallet;
 import zapsolutions.zap.util.ZapLog;
 
 
-public class SettingsFragment extends PreferenceFragmentCompat implements UserGuardianInterface {
+public class SettingsFragment extends PreferenceFragmentCompat{
 
     private static final String LOG_TAG = "Settings";
 
-
-    private UserGuardian mUG;
     private SwitchPreference mSwHideTotalBalance;
     private ListPreference mListCurrency;
 
@@ -51,8 +49,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements UserGu
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         // Load the settings from an XML resource
         setPreferencesFromResource(R.xml.settings, rootKey);
-
-        mUG = new UserGuardian(getActivity(), this);
 
         // Update our current selected first currency in the MonetaryUtil
         final ListPreference listBtcUnit = findPreference("firstCurrency");
@@ -295,11 +291,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements UserGu
         });
     }
 
-
-    @Override
-    public void guardianDialogConfirmed(String DialogName) {
-
-    }
 
     private CharSequence[] joinCharSequenceArrays(CharSequence[] first, CharSequence[] second) {
         List<CharSequence> both = new ArrayList<CharSequence>(first.length + second.length);

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -47,6 +47,12 @@
 
         <SwitchPreference
             android:defaultValue="true"
+            android:key="scramblePin"
+            android:title="@string/settings_scramblePin"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreference
+            android:defaultValue="true"
             android:key="preventScreenRecording"
             android:title="@string/settings_preventScreenRecording"
             app:iconSpaceReserved="false" />

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -85,12 +85,6 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreference
-            android:defaultValue="true"
-            android:key="scramblePin"
-            android:title="@string/settings_scramblePin"
-            app:iconSpaceReserved="false" />
-
-        <SwitchPreference
             android:defaultValue="false"
             android:key="hideTotalBalance"
             android:title="@string/settings_hideTotalBalance"


### PR DESCRIPTION
### Motivation:
An unexperienced user should not be overwhelmed with options. This is a option that will rarely be used and therefore should be under advanced options.