### PR TITLE
Add Issue Template Front Matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,8 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Description


### PR DESCRIPTION
## Description
Previous PR didn't include this meta data.
Added the so called front matter to the issue templates, so GitHub can identify them as such.
See: https://help.github.com/en/articles/about-issue-and-pull-request-templates

## Motivation and Context
In order to chose between the templates when adding an issue the front matter has to be set.

## How Has This Been Tested?


## Screenshots (if appropriate):
![](https://help.github.com/assets/images/help/issues/new-issue-page-with-multiple-templates.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.