### PR TITLE
Add show memo in payment history for ln payments

### DIFF
--- a/app/src/main/java/zapsolutions/zap/historyList/LnPaymentViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/historyList/LnPaymentViewHolder.java
@@ -28,7 +28,7 @@ import zapsolutions.zap.util.ZapLog;
 
 public class LnPaymentViewHolder extends RecyclerView.ViewHolder {
 
-    private static final String LOG_TAG = "Payment List View Holder";
+    private static final String LOG_TAG = "LnPaymentViewHolder";
 
     private ImageView mIcon;
     private TextView mTimeOfDay;
@@ -90,7 +90,7 @@ public class LnPaymentViewHolder extends RecyclerView.ViewHolder {
         // Set description
         mDescription.setVisibility(View.GONE);
 
-        if (!lnPaymentItem.getPayment().getPaymentRequest().equals("")) {
+        if (!lnPaymentItem.getPayment().getPaymentRequest().isEmpty()) {
             // This will only be true for payments done with LND 0.7.0-beta and later
             decodeLightningInvoice(lnPaymentItem.getPayment().getPaymentRequest());
         }
@@ -116,7 +116,7 @@ public class LnPaymentViewHolder extends RecyclerView.ViewHolder {
                 try {
                     PayReq paymentRequest = payReqFuture.get();
 
-                    if (!paymentRequest.getDescription().equals("")) {
+                    if (!paymentRequest.getDescription().isEmpty()) {
                         // Set description
                         mDescription.setVisibility(View.VISIBLE);
                         mDescription.setText(paymentRequest.getDescription());

--- a/app/src/main/java/zapsolutions/zap/historyList/LnPaymentViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/historyList/LnPaymentViewHolder.java
@@ -9,14 +9,26 @@ import android.widget.Toast;
 
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.concurrent.ExecutionException;
 
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.github.lightningnetwork.lnd.lnrpc.LightningGrpc;
+import com.github.lightningnetwork.lnd.lnrpc.PayReq;
+import com.github.lightningnetwork.lnd.lnrpc.PayReqString;
+import com.google.common.util.concurrent.ListenableFuture;
+
 import zapsolutions.zap.R;
+import zapsolutions.zap.connection.LndConnection;
+import zapsolutions.zap.util.ExecuteOnCaller;
 import zapsolutions.zap.util.MonetaryUtil;
 import zapsolutions.zap.util.OnSingleClickListener;
+import zapsolutions.zap.util.ZapLog;
 
 public class LnPaymentViewHolder extends RecyclerView.ViewHolder {
+
+    private static final String LOG_TAG = "Payment List View Holder";
 
     private ImageView mIcon;
     private TextView mTimeOfDay;
@@ -54,10 +66,6 @@ public class LnPaymentViewHolder extends RecyclerView.ViewHolder {
         // Set state
         mTransactionState.setText(R.string.sent);
 
-        // Set description
-        mDescription.setVisibility(View.GONE);
-        // memo is not yet available in lnPayments in LND;
-
         // Set amount
         long amt = lnPaymentItem.getPayment().getValueSat();
         mAmount.setText("- " + MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(amt));
@@ -77,5 +85,51 @@ public class LnPaymentViewHolder extends RecyclerView.ViewHolder {
                 Toast.makeText(mContext, R.string.coming_soon, Toast.LENGTH_SHORT).show();
             }
         });
+
+
+        // Set description
+        mDescription.setVisibility(View.GONE);
+
+        if (!lnPaymentItem.getPayment().getPaymentRequest().equals("")) {
+            // This will only be true for payments done with LND 0.7.0-beta and later
+            decodeLightningInvoice(lnPaymentItem.getPayment().getPaymentRequest());
+        }
+
     }
+
+    private void decodeLightningInvoice(String invoice) {
+
+        // decode lightning invoice
+        LightningGrpc.LightningFutureStub asyncPayReqClient = LightningGrpc
+                .newFutureStub(LndConnection.getInstance().getSecureChannel())
+                .withCallCredentials(LndConnection.getInstance().getMacaroon());
+
+        PayReqString decodePaymentRequest = PayReqString.newBuilder()
+                .setPayReq(invoice)
+                .build();
+
+        final ListenableFuture<PayReq> payReqFuture = asyncPayReqClient.decodePayReq(decodePaymentRequest);
+
+        payReqFuture.addListener(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    PayReq paymentRequest = payReqFuture.get();
+
+                    if (!paymentRequest.getDescription().equals("")) {
+                        // Set description
+                        mDescription.setVisibility(View.VISIBLE);
+                        mDescription.setText(paymentRequest.getDescription());
+                    }
+
+                    // ZapLog.debug(LOG_TAG, String.valueOf(paymentsResponse.toString()));
+                } catch (InterruptedException e) {
+                    ZapLog.debug(LOG_TAG, "Decode payment request interrupted.");
+                } catch (ExecutionException e) {
+                    ZapLog.debug(LOG_TAG, "Exception in decode payment request task.");
+                }
+            }
+        }, new ExecuteOnCaller());
+    }
+
 }


### PR DESCRIPTION
- only available for lnpayments done in lnd 0.7.0-beta or later

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the memo field for payments in the history.
Only payments done with lnd 0.7.0 or later will show a description, as this was not exposed before.

Please note that this is not an ideal implementation.
For each payment a decodePaymentReqest call has to be made. There is currently no other way to do this as the memo is not exposed directly. 
One solution would be to write an own lightning payment reqest decoder in java, which is quite complex though.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It makes it a lot easier to see which payment had which purpose.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on lnd 0.7.0-beta, Samsung S9, API 29

## Screenshots (if appropriate):
![Screenshot_20190706-184050_Zap Debug](https://user-images.githubusercontent.com/15313630/60759292-19489f00-a023-11e9-998a-7f52f8e784c6.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.