### PR TITLE
Add missing Bulgarian string

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -69,7 +69,7 @@
     <string name="max_amount">Максимално Кол-во:</string>
     <string name="retry">Нов опит</string>
     <string name="loading">Зареждане</string>
-
+    <string name="pay">Плащане</string>
 
     <string name="activity_receive">Получаване</string>
     <string name="activity_send">Изпращане</string>


### PR DESCRIPTION
Hopefully this fixes this issue(The pay button is not translated.):
![zap](https://user-images.githubusercontent.com/42069389/62826077-1dd21b80-bbbe-11e9-8990-275e7069d64f.jpg)
