### PR TITLE
added Blockstream's v3 Tor address to Block Explorer options

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
@@ -34,10 +34,8 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 if (newValue != null && newValue.toString().equalsIgnoreCase("Blockstream (v3 Tor)")) {
                     Toast.makeText(getActivity(), R.string.settings_blockExplorer_tor_toast, Toast.LENGTH_LONG).show();
-                    return true;
-                } else {
-                    return true;
                 }
+                return true;
             }
         });
 

--- a/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
@@ -2,6 +2,8 @@ package zapsolutions.zap.fragments;
 
 import android.os.Bundle;
 import android.view.WindowManager;
+import android.widget.Toast;
+import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SwitchPreference;
@@ -16,6 +18,7 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
     private UserGuardian mUG;
     private SwitchPreference mSwScrambledPin;
     private SwitchPreference mSwScreenProtection;
+    private ListPreference mSwBlockExplorer;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -24,6 +27,19 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
 
         mUG = new UserGuardian(getActivity(), this);
 
+        // On change block explorer option
+        mSwBlockExplorer = findPreference("blockExplorer");
+        mSwBlockExplorer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (newValue != null && newValue.toString().equalsIgnoreCase("Blockstream (v3 Tor)")) {
+                    Toast.makeText(getActivity(), R.string.settings_blockExplorer_tor_toast, Toast.LENGTH_LONG).show();
+                    return true;
+                } else {
+                    return true;
+                }
+            }
+        });
 
         // On change scramble pin option
         mSwScrambledPin = findPreference("scramblePin");

--- a/app/src/main/java/zapsolutions/zap/util/BlockExplorer.java
+++ b/app/src/main/java/zapsolutions/zap/util/BlockExplorer.java
@@ -36,6 +36,10 @@ public class BlockExplorer {
                 networkID = mainnet ? "" : "testnet/";
                 url = "https://blockstream.info/" + networkID + "tx/" + transactionID;
                 break;
+            case "Blockstream (v3 Tor)":
+                networkID = mainnet ? "" : "testnet/";
+                url = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion" + networkID + "tx/" + transactionID;
+                break;
             case "Smartbit":
                 networkID = mainnet ? "www" : "testnet";
                 url = "https://" + networkID + ".smartbit.com.au/tx/" + transactionID;
@@ -81,6 +85,10 @@ public class BlockExplorer {
             case "Blockstream":
                 networkID = mainnet ? "" : "testnet/";
                 url = "https://blockstream.info/" + networkID + "address/" + address;
+                break;
+            case "Blockstream (v3 Tor)":
+                networkID = mainnet ? "" : "testnet/";
+                url = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion" + networkID + "address/" + address;
                 break;
             case "Smartbit":
                 networkID = mainnet ? "www" : "testnet";

--- a/app/src/main/java/zapsolutions/zap/util/BlockExplorer.java
+++ b/app/src/main/java/zapsolutions/zap/util/BlockExplorer.java
@@ -38,7 +38,7 @@ public class BlockExplorer {
                 break;
             case "Blockstream (v3 Tor)":
                 networkID = mainnet ? "" : "testnet/";
-                url = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion" + networkID + "tx/" + transactionID;
+                url = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/" + networkID + "tx/" + transactionID;
                 break;
             case "Smartbit":
                 networkID = mainnet ? "www" : "testnet";
@@ -88,7 +88,7 @@ public class BlockExplorer {
                 break;
             case "Blockstream (v3 Tor)":
                 networkID = mainnet ? "" : "testnet/";
-                url = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion" + networkID + "address/" + address;
+                url = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/" + networkID + "address/" + address;
                 break;
             case "Smartbit":
                 networkID = mainnet ? "www" : "testnet";

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -27,6 +27,7 @@
     <string-array name="blockExplorer">
         <item>BlockCypher</item>
         <item>Blockstream</item>
+        <item>Blockstream (v3 Tor)</item>
         <item>Smartbit</item>
         <item>Blockchain Reader (Yogh)</item>
         <item>OXT</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
 
 
     <string name="settings_blockExplorer">Block Explorer</string>
+    <string name="settings_blockExplorer_tor_toast">Tor Browser for Android is required.</string>
     <string name="settings_addressType">Bitcoin Address Type</string>
 
     <string-array name="settings_receiveAddressDisplayValues">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added Blockstream's v3 Tor address to list of available options under `Advanced Settings` -> `Block Explorer`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds Blockstream's v3 Tor address to the list of available Block Explorer options, such that user's have the ability to elect for more privacy focused means to looking up TXs without exposing their networking meta data, potentially doxxing their UTXOs.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/LN-Zap/zap-android/issues/79#issue-479651566

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran the changes on a Virtual Device of a Pixel 3 XL (API 28), Nexus S (API 28), Nexus 5X (API 29), as well as a physical Samsung S9+ (API 27).

<!--- Include details of your testing environment, and the tests you ran to -->
Was able to select the option, but wasn't able to text actually viewing the TX, as the functionality is not released yet.
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/44778092/62873613-bb783880-bced-11e9-8e4f-4c26932d658e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.