### PR TITLE
Handle zero sat transactions in transaction history

### DIFF
--- a/app/src/main/java/zapsolutions/zap/transactionHistory/TransactionHistoryFragment.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/TransactionHistoryFragment.java
@@ -179,7 +179,9 @@ public class TransactionHistoryFragment extends Fragment implements Wallet.Histo
                     if (Wallet.getInstance().isTransactionInternal(t)) {
                         internalTransactions.add(onChainTransactionItem);
                     } else {
-                        normalPayments.add(onChainTransactionItem);
+                        if (t.getAmount() != 0) {
+                            normalPayments.add(onChainTransactionItem);
+                        }
                     }
                 }
             }

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/OnChainTransactionViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/OnChainTransactionViewHolder.java
@@ -32,9 +32,10 @@ public class OnChainTransactionViewHolder extends TransactionViewHolder {
             switch (amount.compareTo(0L)) {
                 case 0:
                     // amount = 0
-                    setAmount(amount, true);
-                    setPrimaryDescription(mContext.getString(R.string.internal));
-                    setSecondaryDescription("", false);
+                    setAmount(amount, false);
+                    setPrimaryDescription(mContext.getString(R.string.force_closed_channel));
+                    String aliasForceClose = Wallet.getInstance().getNodeAliasFromChannelTransaction(onChainTransactionItem.getOnChainTransaction(), mContext);
+                    setSecondaryDescription(aliasForceClose, true);
                     break;
                 case 1:
                     // amount > 0 (Channel closed)

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -1251,10 +1251,6 @@ public class Wallet {
             }
         }
 
-        if (transaction.getAmount() == 0) {
-            return true;
-        }
-
         return false;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="internal">Internal</string>
     <string name="opened_channel">Channel opened</string>
     <string name="closed_channel">Channel closed</string>
+    <string name="force_closed_channel">Channel force closed</string>
     <string name="filter_transactions">Filter transactions</string>
     <string name="normal_payments">Normal Payments</string>
     <string name="expired_requests">Expired Requests</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handle zero sat transactions in transaction history

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There were some "internal" transactions with 0 sat value. These were confusing and did some of them where not correctly linked to a channel event. 
The ones that still could not be linked to any event are now filtered out.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Samsung S9, API 29

## Screenshots (if appropriate):
This PR:
![Screenshot_1566573521](https://user-images.githubusercontent.com/15313630/63603751-86f85c80-c5ca-11e9-8809-cc93e5538bc5.png)

Before:
![Screenshot_1566573562](https://user-images.githubusercontent.com/15313630/63603752-86f85c80-c5ca-11e9-8e93-58a2220556fb.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.