### PR TITLE
Allow paste without camera permission

### DIFF
--- a/app/src/main/java/zapsolutions/zap/SendActivity.java
+++ b/app/src/main/java/zapsolutions/zap/SendActivity.java
@@ -68,24 +68,21 @@ public class SendActivity extends BaseScannerActivity implements ZBarScannerView
                 PermissionsUtil.requestCameraPermission(SendActivity.this, true);
             }
         }
+
+        // Action when clicked on "paste"
+        Button btnPaste = findViewById(R.id.scannerPaste);
+        btnPaste.setOnClickListener(v -> {
+            try {
+                validateInvoice(ClipBoardUtil.getPrimaryContent(getApplicationContext()));
+            } catch (NullPointerException e) {
+                showError(getResources().getString(R.string.error_emptyClipboardPayment), 4000);
+            }
+        });
     }
 
     private void showCameraView() {
         ViewGroup contentFrame = findViewById(R.id.content_frame);
         contentFrame.addView(mScannerView);
-
-        // Action when clicked on "paste"
-        Button btnPaste = findViewById(R.id.scannerPaste);
-        btnPaste.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                try {
-                    validateInvoice(ClipBoardUtil.getPrimaryContent(getApplicationContext()));
-                } catch (NullPointerException e) {
-                    showError(getResources().getString(R.string.error_emptyClipboardPayment), 4000);
-                }
-            }
-        });
 
         // Action when clicked on "flash button"
         mBtnFlashlight = findViewById(R.id.scannerFlashButton);


### PR DESCRIPTION
## Description
Currently the user cannot paste an invoice/address to pay when not giving the camera permission.

## Motivation and Context
Allow user to pay without giving camera permission.

## How Has This Been Tested?
Tested on Pixel 3, API 29. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.