### PR TITLE
Adjust scanner tolerance and viewfinder to square

### DIFF
--- a/app/src/main/java/zapsolutions/zap/baseClasses/BaseScannerActivity.java
+++ b/app/src/main/java/zapsolutions/zap/baseClasses/BaseScannerActivity.java
@@ -56,7 +56,11 @@ public abstract class BaseScannerActivity extends BaseAppCompatActivity implemen
         mHighlightColor = ContextCompat.getColor(this, R.color.lightningOrange);
         mGrayColor = ContextCompat.getColor(this, R.color.gray);
 
+        // Scanner settings
+        mScannerView.setAspectTolerance(0.5f);
+
         // Styling the scanner view
+        mScannerView.setSquareViewFinder(true);
         mScannerView.setLaserEnabled(false);
         mScannerView.setBorderColor(mHighlightColor);
         mScannerView.setBorderStrokeWidth(20);


### PR DESCRIPTION
Referencing discussion at #106 

Scanner settings adjusted to make a square view finder and to adjust tolerance for better scanning on smaller devices.

Tested on local device with successful results. This should be a non-breaking change but should be tested on more devices.