### PR TITLE
Display delays for force close channels

### DIFF
--- a/app/src/main/res/layout/bsd_channeldetail.xml
+++ b/app/src/main/res/layout/bsd_channeldetail.xml
@@ -233,6 +233,31 @@
         app:layout_constraintTop_toBottomOf="@id/fundingTxText"
         tools:visibility="visible">
 
+        <TextView
+            android:id="@+id/closingTxTimeText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textSize="15sp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/closingTxTimeLabel"
+            tools:visibility="visible"
+            tools:text="20 hr 35 min" />
+
+        <TextView
+            android:id="@+id/closingTxTimeLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/channel_close_time"
+            android:textSize="15sp"
+            android:visibility="gone"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/closingTxText"
+            tools:text="Closing in"
+            tools:visibility="visible"/>
+
         <ImageView
             android:id="@+id/separator_4"
             android:layout_width="0dp"
@@ -305,9 +330,9 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:background="@drawable/bg_clickable_item"
+        android:textAllCaps="false"
         android:textColor="@color/lightningOrange"
         android:visibility="gone"
-        android:textAllCaps="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/spacer"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,8 @@
     <string name="channel_close_force">Force Close Channel</string>
     <string name="channel_close_error">Error occurred while closing channel</string>
     <string name="channel_close_confirmation">Do you really want to close the channel with:\n%s\n</string>
-    <string name="channel_close_force_confirmation">Do you really want to force close the channel with:\n%s\n</string>
+    <string name="channel_close_force_confirmation">Do you really want to force close the channel with:\n%1$s\n\nYour funds will be locked up for %2$s.</string>
+    <string name="channel_close_time">Closing Time Delay</string>
     <string name="channel_open">Open Channel</string>
     <string name="channel_open_successful">Channel opened successfully</string>
     <string name="channel_open_error">Error occurred while opening channel</string>
@@ -228,8 +229,6 @@
     </string-array>
 
     <string name="settings_lnRequestExpiryTitle">Lightning Request Expiry</string>
-
-
 
 
     <string name="error">Error</string>


### PR DESCRIPTION
## Description
Addressing #94 

## Motivation and Context
Let the user know how long a force close will take.
Will be shown on close confirmation dialog and channel detail.

## How Has This Been Tested?
Pixel 2, simnet

## Screenshots (if appropriate):
![details](https://user-images.githubusercontent.com/11649986/65819191-eecd4300-e219-11e9-986f-c7e7fbc7e7d2.png)
![dialog](https://user-images.githubusercontent.com/11649986/65819192-eecd4300-e219-11e9-966c-df46d7494a2b.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.