### PR TITLE
Add option to adjust lightning fee limit

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/AdvancedSettingsFragment.java
@@ -10,6 +10,7 @@ import androidx.preference.SwitchPreference;
 import zapsolutions.zap.R;
 import zapsolutions.zap.interfaces.UserGuardianInterface;
 import zapsolutions.zap.util.BiometricUtil;
+import zapsolutions.zap.util.RefConstants;
 import zapsolutions.zap.util.UserGuardian;
 
 
@@ -21,6 +22,7 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
     private SwitchPreference mSwScreenProtection;
     private ListPreference mListBlockExplorer;
     private ListPreference mListLnExpiry;
+    private ListPreference mListFeeLimit;
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -45,9 +47,17 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
         mListLnExpiry = findPreference("lightning_expiry");
         createLnExpiryDisplayEntries();
 
+        mListFeeLimit = findPreference("lightning_feeLimit");
+        mListFeeLimit.setOnPreferenceChangeListener((preference, newValue) -> {
+            setFeeSummary(preference, newValue.toString());
+            return true;
+        });
+
+        setFeeSummary(mListFeeLimit, mListFeeLimit.getValue());
+
         // Remove Biometrics setting if it is not available anyway on the device.
         SwitchPreference swBiometrics = findPreference("biometricsEnabled");
-        if (!BiometricUtil.hardwareAvailable()){
+        if (!BiometricUtil.hardwareAvailable()) {
             swBiometrics.setVisible(false);
         }
 
@@ -84,6 +94,11 @@ public class AdvancedSettingsFragment extends PreferenceFragmentCompat implement
 
     }
 
+    private void setFeeSummary(Preference preference, String value) {
+        String s = value.replace("%", "%%");
+        String string = getString(R.string.fee_limit_threshold, RefConstants.LN_PAYMENT_FEE_THRESHOLD, s);
+        preference.setSummary(string);
+    }
 
     @Override
     public void guardianDialogConfirmed(String DialogName) {

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -3,6 +3,7 @@ package zapsolutions.zap.fragments;
 
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
@@ -28,6 +29,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 import androidx.core.content.ContextCompat;
@@ -111,7 +113,9 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
     private String mLnInvoice;
 
     private boolean mAmountValid = true;
-    private long mMaxLightningFee = 0;
+
+    private float mLnFeePercentCalculated;
+    private float mLnFeePercentSettingLimit;
 
 
     @Nullable
@@ -143,6 +147,8 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
         if (PrefsUtil.preventScreenRecording()) {
             getDialog().getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
         }
+
+        setLightningFeeLimit();
 
         mRootLayout = view.findViewById(R.id.rootLayout);
         mIvBsdIcon = view.findViewById(R.id.bsdIcon);
@@ -504,85 +510,39 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
 
                     // send lightning payment
                     if (PrefsUtil.isWalletSetup()) {
-
-                        switchToSendProgressScreen();
-
-                        ZapLog.debug(LOG_TAG, "Trying to send lightning payment...");
-
                         SendRequest.Builder srb = SendRequest.newBuilder();
-                        srb.setPaymentRequest(mLnInvoice);
-                        srb.setFeeLimit(FeeLimit.newBuilder()
-                                .setFixed(mMaxLightningFee)
-                                .build());
 
-                        if (mLnPaymentRequest.getNumSatoshis() == 0) {
-                            srb.setAmt(Long.parseLong(MonetaryUtil.getInstance().convertPrimaryToSatoshi(mEtAmount.getText().toString())));
-                            mTvFinishedText2.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(Long.parseLong(MonetaryUtil.getInstance().convertPrimaryToSatoshi(mEtAmount.getText().toString()))));
-                        } else {
-                            mTvFinishedText2.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(mLnPaymentRequest.getNumSatoshis()));
-                        }
+                        // only check fee limit if user has enabled and payment above ignore limit
+                        int paymentIgnoreFeeLimit = 100;
+                        if (mLnFeePercentSettingLimit != 1 && mLnPaymentRequest.getNumSatoshis() > paymentIgnoreFeeLimit) {
 
-                        SendRequest sendRequest = srb.build();
+                            if (mLnFeePercentCalculated > mLnFeePercentSettingLimit) {
+                                // fee is higher than settings, ask user
+                                String feeLimitString = getString(R.string.fee_limit_exceeded, mLnFeePercentCalculated * 100, mLnFeePercentSettingLimit * 100);
+                                AlertDialog.Builder adb = new AlertDialog.Builder(getContext())
+                                        .setTitle(R.string.details)
+                                        .setMessage(feeLimitString)
+                                        .setCancelable(true)
+                                        .setPositiveButton(R.string.yes, (dialog, whichButton) -> sendPayment(srb))
+                                        .setNegativeButton(R.string.no, (dialog, whichButton) -> {
+                                        });
 
-
-                        LightningGrpc.LightningFutureStub asyncLightningSendClient = LightningGrpc
-                                .newFutureStub(LndConnection.getInstance().getSecureChannel())
-                                .withCallCredentials(LndConnection.getInstance().getMacaroon());
-
-                        final ListenableFuture<SendResponse> sendFuture = asyncLightningSendClient.sendPaymentSync(sendRequest);
-
-                        sendFuture.addListener(new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    SendResponse sendResponse = sendFuture.get();
-
-                                    // updated the history, so it is shown the next time the user views it
-                                    Wallet.getInstance().updateLightningPaymentHistory();
-
-                                    ZapLog.debug(LOG_TAG, sendResponse.toString());
-
-                                    // show success animation
-                                    Handler handler = new Handler();
-                                    handler.postDelayed(new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            if (sendResponse.getPaymentError().equals("")) {
-                                                switchToSuccessScreen();
-                                            } else {
-                                                String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ": ";
-                                                String error = errorPrefix + sendResponse.getPaymentError();
-                                                switchToFailedScreen(error);
-                                            }
-
-                                        }
-                                    }, 300);
-
-                                } catch (InterruptedException e) {
-                                    ZapLog.debug(LOG_TAG, "send request interrupted.");
-                                    switchToFailedScreen("Request interrupted");
-                                } catch (ExecutionException e) {
-                                    ZapLog.debug(LOG_TAG, "Exception in send request task.");
-                                    ZapLog.debug(LOG_TAG, e.getMessage());
-
-                                    // possible error messages: checksum mismatch, decoded address is of unknown format
-
-                                    ZapLog.debug(LOG_TAG, "Error during payment!");
-                                    ZapLog.debug(LOG_TAG, e.getMessage());
-
-                                    Handler handler = new Handler();
-                                    handler.postDelayed(new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ":";
-                                            switchToFailedScreen(e.getCause().getMessage().replace("UNKNOWN:", errorPrefix));
-                                        }
-                                    }, 300);
+                                Dialog dlg = adb.create();
+                                // Apply FLAG_SECURE to dialog to prevent screen recording
+                                if (PrefsUtil.preventScreenRecording()) {
+                                    dlg.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
                                 }
-
+                                dlg.show();
+                                return;
+                            } else {
+                                // could not calculate fee, or fee is below limit
+                                // set limit from settings and try payment
+                                srb.setFeeLimit(FeeLimit.newBuilder()
+                                        .setPercent((long) (mLnFeePercentSettingLimit * 100)))
+                                        .build();
                             }
-                        }, new ExecuteOnCaller());
-
+                        }
+                        sendPayment(srb);
                     } else {
                         // Demo Mode
                         Toast.makeText(getActivity(), R.string.demo_setupWalletFirst, Toast.LENGTH_SHORT).show();
@@ -631,6 +591,92 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
         });
 
         return view;
+    }
+
+    private void setLightningFeeLimit() {
+        String lightning_feeLimit = PrefsUtil.getPrefs().getString("lightning_feeLimit", "3%");
+        String feePercent = lightning_feeLimit.replace("%", "");
+
+        if (feePercent.equals("None")) {
+            mLnFeePercentSettingLimit = 1;
+        } else {
+            mLnFeePercentSettingLimit = Integer.parseInt(feePercent) / 100f;
+        }
+    }
+
+    private void sendPayment(SendRequest.Builder paymentRequestBuilder) {
+        switchToSendProgressScreen();
+
+        ZapLog.debug(LOG_TAG, "Trying to send lightning payment...");
+
+        paymentRequestBuilder.setPaymentRequest(mLnInvoice);
+
+        if (mLnPaymentRequest.getNumSatoshis() == 0) {
+            paymentRequestBuilder.setAmt(Long.parseLong(MonetaryUtil.getInstance().convertPrimaryToSatoshi(mEtAmount.getText().toString())));
+            mTvFinishedText2.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(Long.parseLong(MonetaryUtil.getInstance().convertPrimaryToSatoshi(mEtAmount.getText().toString()))));
+        } else {
+            mTvFinishedText2.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(mLnPaymentRequest.getNumSatoshis()));
+        }
+
+        SendRequest sendRequest = paymentRequestBuilder.build();
+
+        LightningGrpc.LightningFutureStub asyncLightningSendClient = LightningGrpc
+                .newFutureStub(LndConnection.getInstance().getSecureChannel())
+                .withCallCredentials(LndConnection.getInstance().getMacaroon());
+
+        final ListenableFuture<SendResponse> sendFuture = asyncLightningSendClient.sendPaymentSync(sendRequest);
+
+        sendFuture.addListener(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    SendResponse sendResponse = sendFuture.get();
+
+                    // updated the history, so it is shown the next time the user views it
+                    Wallet.getInstance().updateLightningPaymentHistory();
+
+                    ZapLog.debug(LOG_TAG, sendResponse.toString());
+
+                    // show success animation
+                    Handler handler = new Handler();
+                    handler.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (sendResponse.getPaymentError().equals("")) {
+                                switchToSuccessScreen();
+                            } else {
+                                String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ": ";
+                                String error = errorPrefix + sendResponse.getPaymentError();
+                                switchToFailedScreen(error);
+                            }
+
+                        }
+                    }, 300);
+
+                } catch (InterruptedException e) {
+                    ZapLog.debug(LOG_TAG, "send request interrupted.");
+                    switchToFailedScreen("Request interrupted");
+                } catch (ExecutionException e) {
+                    ZapLog.debug(LOG_TAG, "Exception in send request task.");
+                    ZapLog.debug(LOG_TAG, e.getMessage());
+
+                    // possible error messages: checksum mismatch, decoded address is of unknown format
+
+                    ZapLog.debug(LOG_TAG, "Error during payment!");
+                    ZapLog.debug(LOG_TAG, e.getMessage());
+
+                    Handler handler = new Handler();
+                    handler.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ":";
+                            switchToFailedScreen(e.getCause().getMessage().replace("UNKNOWN:", errorPrefix));
+                        }
+                    }, 300);
+                }
+
+            }
+        }, new ExecuteOnCaller());
     }
 
     // This gets executed after onCreateView. We edit the bottomSheetBehavior to not react to swipes
@@ -969,7 +1015,9 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
         QueryRoutesRequest asyncQueryRoutesRequest = QueryRoutesRequest.newBuilder()
                 .setPubKey(pubKey)
                 .setAmt(amount)
+                .setUseMissionControl(true)
                 .build();
+
         final ListenableFuture<QueryRoutesResponse> queryRoutesFuture = asyncQueryRoutesClient.queryRoutes(asyncQueryRoutesRequest);
 
         queryRoutesFuture.addListener(new Runnable() {
@@ -982,29 +1030,18 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
                         ZapLog.debug(LOG_TAG, "No route found.");
                         setFeeFailure();
                     } else {
+                        Route route = queryRoutesResponse.getRoutes(0);
 
-                        Route firstRoute = queryRoutesResponse.getRoutes(0);
-                        Route lastRoute = queryRoutesResponse.getRoutes(queryRoutesResponse.getRoutesCount() - 1);
-
-                        long feeLowerBoundSat = firstRoute.getTotalFeesMsat() / 1000;
-                        // For the upper bound we have to add one sat as the value gets truncated.
+                        // We have to add one sat as the value gets truncated.
                         // Example: If the fee was actually 700 Msat it would result in 0 sat (= 0 Msat)
                         //          and could lead to "no route" error when applied as fee limit.
-                        long feeUpperBoundSat = (lastRoute.getTotalFeesMsat() / 1000) + 1;
+                        long calculatedFeeSats = (route.getTotalFeesMsat() / 1000) + 1;
 
-                        String feeLowerBound = MonetaryUtil.getInstance().getPrimaryDisplayAmount(feeLowerBoundSat);
-                        String feeUpperBound = MonetaryUtil.getInstance().getPrimaryDisplayAmount(feeUpperBoundSat);
+                        mLnFeePercentCalculated = ((float) calculatedFeeSats / amount);
+                        String feePercentageString = " (" + String.format("%.1f", mLnFeePercentCalculated * 100) + "%)";
 
-                        String feeString;
-
-                        mMaxLightningFee = feeUpperBoundSat;
-
-                        if (feeLowerBound.equals(feeUpperBound)) {
-                            feeString = feeLowerBound + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
-                        } else {
-                            feeString = feeLowerBound + "-" + feeUpperBound + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
-                        }
-
+                        String feeString = MonetaryUtil.getInstance().getPrimaryDisplayAmount(calculatedFeeSats) + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
+                        feeString = feeString + feePercentageString;
                         setCalculatedFeeAmount(feeString);
                     }
 

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -520,7 +520,7 @@ public class SendBSDFragment extends BottomSheetDialogFragment {
                                 // fee is higher than settings, ask user
                                 String feeLimitString = getString(R.string.fee_limit_exceeded, mLnFeePercentCalculated * 100, mLnFeePercentSettingLimit * 100);
                                 AlertDialog.Builder adb = new AlertDialog.Builder(getContext())
-                                        .setTitle(R.string.details)
+                                        .setTitle(R.string.fee_limit_title)
                                         .setMessage(feeLimitString)
                                         .setCancelable(true)
                                         .setPositiveButton(R.string.yes, (dialog, whichButton) -> sendPayment(srb))

--- a/app/src/main/java/zapsolutions/zap/util/RefConstants.java
+++ b/app/src/main/java/zapsolutions/zap/util/RefConstants.java
@@ -20,6 +20,12 @@ public class RefConstants {
     public static final int VIBRATE_SHORT = 50;
     public static final int VIBRATE_LONG = 200;
 
+    /* This value is a threshold used to determine if the user specified fee limit should
+    be taken into consideration.
+    If the payment amount is below/equal to this threshold, the user setting is not used.
+    If the payment amount is above this threshold, the user setting will be considered. */
+    public static final int LN_PAYMENT_FEE_THRESHOLD = 100;
+
     public static final String URL_HELP = "https://docs.zaphq.io/";
     public static final String URL_SUGGESTED_NODES = "https://resources.zaphq.io/api/v1/suggested-nodes";
 

--- a/app/src/main/res/layout/view_lightning_fee.xml
+++ b/app/src/main/res/layout/view_lightning_fee.xml
@@ -6,11 +6,10 @@
 
     <TextView
         android:id="@+id/sendFeeLightningLabel"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="#00000000"
-        android:ems="10"
-        android:maxLength="50"
+        android:maxLength="15"
         android:text="@string/fee"
         android:textAlignment="viewStart"
         android:textSize="20sp"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -50,4 +50,12 @@
         <item>31536000</item>
     </string-array>
 
+    <string-array name="lnFeeLimit">
+        <item>None</item>
+        <item>1%</item>
+        <item>3%</item>
+        <item>5%</item>
+        <item>10%</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,7 +322,8 @@
     <string name="fee_tier_fast_description">Fast Transaction</string>
     <string name="fee_estimated_duration">Estimated Delivery: %1$s</string>
     <string name="fee_not_available">n/A</string>
-    <string name="fee_limit_exceeded">The fee for this payment (%1$.1f%%) exceeds the limit specified in the settings (%2$.0f%%).\n\n Do you really want to pay this invoice?</string>
+    <string name="fee_limit_title">Fee Limit Alert</string>
+    <string name="fee_limit_exceeded">The fee for this payment (%1$.1f%%) exceeds the limit specified in the settings (%2$.0f%%).\n\nDo you really want to pay this invoice?</string>
 
     <string name="unlock_wallet">Unlock Wallet</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,8 +322,11 @@
     <string name="fee_tier_fast_description">Fast Transaction</string>
     <string name="fee_estimated_duration">Estimated Delivery: %1$s</string>
     <string name="fee_not_available">n/A</string>
+
     <string name="fee_limit_title">Fee Limit Alert</string>
+    <string name="fee_limit_threshold">Fee limit for payments above %1$d sats: %2$s</string>
     <string name="fee_limit_exceeded">The fee for this payment (%1$.1f%%) exceeds the limit specified in the settings (%2$.0f%%).\n\nDo you really want to pay this invoice?</string>
+    <string name="fee_limit_exceeded_payment">The fee for this payment (%1$d sats) will be higher than the payment amount (%2$d sats).\n\nDo you really want to pay this invoice?</string>
 
     <string name="unlock_wallet">Unlock Wallet</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     </string-array>
 
     <string name="settings_lnRequestExpiryTitle">Lightning Request Expiry</string>
+    <string name="settings_lnFeeLimitTitle">Lightning Payment Fee Limit</string>
 
 
     <string name="error">Error</string>
@@ -321,6 +322,7 @@
     <string name="fee_tier_fast_description">Fast Transaction</string>
     <string name="fee_estimated_duration">Estimated Delivery: %1$s</string>
     <string name="fee_not_available">n/A</string>
+    <string name="fee_limit_exceeded">The fee for this payment (%1$.1f%%) exceeds the limit specified in the settings (%2$.0f%%).\n\n Do you really want to pay this invoice?</string>
 
     <string name="unlock_wallet">Unlock Wallet</string>
 

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -38,6 +38,15 @@
             android:title="@string/settings_lnRequestExpiryTitle"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="3%"
+            android:entries="@array/lnFeeLimit"
+            android:entryValues="@array/lnFeeLimit"
+            android:key="lightning_feeLimit"
+            android:summary="%s"
+            android:title="@string/settings_lnFeeLimitTitle"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
1. Allow user to set a fee limit for lightning payments.
2. Use mission control for query routes
3. Fix #121 

## Motivation and Context
Fix bug where payments could not be routed to private channels.
Allow user to define a limit for lightning fees.

## How Has This Been Tested?
Testnet, Mainnet

## Screenshots (if appropriate):

![payment_overview](https://user-images.githubusercontent.com/11649986/66562067-134ee680-eb5b-11e9-8060-a99c9c8a65f2.png)

![dialog_alert](https://user-images.githubusercontent.com/11649986/66562066-12b65000-eb5b-11e9-9f24-88a344d60df0.png)

![setting_overview](https://user-images.githubusercontent.com/11649986/66562069-134ee680-eb5b-11e9-898c-4ca077433e21.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.