### PR TITLE
Fix Numpad Bug on smaller devices

### DIFF
--- a/app/src/main/res/layout/bsd_open_channel.xml
+++ b/app/src/main/res/layout/bsd_open_channel.xml
@@ -124,6 +124,15 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <!-- Dummy item to prevent EditText from receiving focus -->
+        <LinearLayout
+            android:layout_width="0px"
+            android:layout_height="0px"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/localAmountInputsView"
             android:layout_width="match_parent"
@@ -213,15 +222,6 @@
                     android:textStyle="italic"
                     tools:text="UNIT" />
             </LinearLayout>
-
-            <!-- Dummy item to prevent EditText from receiving focus -->
-            <LinearLayout
-                android:layout_width="0px"
-                android:layout_height="0px"
-                android:focusable="true"
-                android:focusableInTouchMode="true"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/localAmountLabel"

--- a/app/src/main/res/layout/bsd_open_channel.xml
+++ b/app/src/main/res/layout/bsd_open_channel.xml
@@ -247,8 +247,6 @@
             android:layout_marginTop="15dp"
             android:layout_marginEnd="25dp"
             android:layout_marginBottom="15dp"
-            android:columnCount="3"
-            android:rowCount="4"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/bsd_receive.xml
+++ b/app/src/main/res/layout/bsd_receive.xml
@@ -395,8 +395,6 @@
         android:layout_marginTop="15dp"
         android:layout_marginEnd="25dp"
         android:layout_marginBottom="15dp"
-        android:columnCount="3"
-        android:rowCount="4"
         android:visibility="visible"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/bsd_send.xml
+++ b/app/src/main/res/layout/bsd_send.xml
@@ -316,8 +316,6 @@
         android:layout_marginTop="15dp"
         android:layout_marginEnd="25dp"
         android:layout_marginBottom="15dp"
-        android:columnCount="3"
-        android:rowCount="4"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/numpad.xml
+++ b/app/src/main/res/layout/numpad.xml
@@ -1,141 +1,149 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-
-<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/Numpad"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:columnCount="3"
-    android:rowCount="4">
+    android:layout_height="wrap_content">
 
     <Button
         android:id="@+id/Numpad1"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
+        style="@style/NumpadButton"
         android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
         android:text="1"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline33"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/Numpad2"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
+        style="@style/NumpadButton"
         android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
         android:text="2"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline66"
+        app:layout_constraintStart_toEndOf="@id/guideline33"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/Numpad3"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
+        style="@style/NumpadButton"
         android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
         android:text="3"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/guideline66"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/Numpad4"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="4"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline33"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/Numpad1" />
 
     <Button
         android:id="@+id/Numpad5"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="5"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline66"
+        app:layout_constraintStart_toEndOf="@id/guideline33"
+        app:layout_constraintTop_toBottomOf="@id/Numpad2" />
 
     <Button
         android:id="@+id/Numpad6"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="6"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/guideline66"
+        app:layout_constraintTop_toBottomOf="@id/Numpad3" />
 
     <Button
         android:id="@+id/Numpad7"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="7"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline33"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/Numpad5" />
 
     <Button
         android:id="@+id/Numpad8"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="8"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline66"
+        app:layout_constraintStart_toEndOf="@id/guideline33"
+        app:layout_constraintTop_toBottomOf="@id/Numpad5" />
 
     <Button
         android:id="@+id/Numpad9"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="9"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/guideline66"
+        app:layout_constraintTop_toBottomOf="@id/Numpad6" />
 
     <Button
         android:id="@+id/NumpadDot"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="."
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline33"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/Numpad7" />
 
     <Button
         android:id="@+id/Numpad0"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:text="0"
-        android:textColor="@color/white"
-        android:textSize="30dp"
-        android:typeface="sans" />
+        app:layout_constraintEnd_toStartOf="@id/guideline66"
+        app:layout_constraintStart_toEndOf="@id/guideline33"
+        app:layout_constraintTop_toBottomOf="@id/Numpad8" />
 
     <ImageButton
         android:id="@+id/NumpadBack"
-        android:layout_height="45dp"
-        android:layout_columnWeight="1"
-        android:layout_margin="5dp"
-        android:background="@drawable/bg_clickable_item"
+        style="@style/NumpadButton"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="5dp"
         android:src="@drawable/ic_delete_black_36dp"
-        android:tint="@color/white" />
+        android:tint="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/guideline66"
+        app:layout_constraintTop_toBottomOf="@id/Numpad9" />
 
-</GridLayout>
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline66"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.66" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline33"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.33" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-h480dp/dimens.xml
+++ b/app/src/main/res/values-h480dp/dimens.xml
@@ -6,4 +6,7 @@
     <dimen name="qr_scanner_paste_button_marginBottom">5dp</dimen>
     <dimen name="qr_scanner_button_width">230dp</dimen>
     <dimen name="qr_scanner_button_height">40dp</dimen>
+
+    <dimen name="numpad_button_height">35dp</dimen>
+    <dimen name="numpad_button_text_size">25sp</dimen>
 </resources>

--- a/app/src/main/res/values-h600dp/dimens.xml
+++ b/app/src/main/res/values-h600dp/dimens.xml
@@ -6,4 +6,7 @@
     <dimen name="qr_scanner_paste_button_marginBottom">10dp</dimen>
     <dimen name="qr_scanner_button_width">250dp</dimen>
     <dimen name="qr_scanner_button_height">55dp</dimen>
+
+    <dimen name="numpad_button_height">45dp</dimen>
+    <dimen name="numpad_button_text_size">30sp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,7 @@
     <dimen name="qr_scanner_paste_button_marginBottom">5dp</dimen>
     <dimen name="qr_scanner_button_width">150dp</dimen>
     <dimen name="qr_scanner_button_height">35dp</dimen>
+
+    <dimen name="numpad_button_height">35dp</dimen>
+    <dimen name="numpad_button_text_size">25sp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -88,4 +88,12 @@
     <style name="ZapBottomSheetDialogTheme" parent="BaseZapBottomSheetDialog" />
 
 
+    <style name="NumpadButton" parent="Widget.AppCompat.Button">
+        <item name="android:layout_height">@dimen/numpad_button_height</item>
+        <item name="android:layout_width">0dp</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:background">@drawable/bg_clickable_item</item>
+        <item name="android:textSize">@dimen/numpad_button_text_size</item>
+        <item name="android:typeface">sans</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Description
There is a bug in `Gridlayout` which breaks the view on smaller devices.
See: [Google Issuetracker](https://issuetracker.google.com/issues/37108515) / [StackOverflow](https://stackoverflow.com/questions/42173015/gridlayout-collapses-on-small-display)

## Motivation and Context
1. Exchanged `Gridlayout` with `ContraintLayout` to fix the issue.
2. Fixed a focus issue on OpenChannel view

## How Has This Been Tested?
Pixel 2, Pixel 3, Nexus S

## Screenshots (if appropriate):

Before:

![Screenshot_1570884886](https://user-images.githubusercontent.com/11649986/66701798-c3118900-ed00-11e9-9e49-d4941bf04f27.png)

After:

![Screenshot_1570884723](https://user-images.githubusercontent.com/11649986/66701797-c3118900-ed00-11e9-9597-73be765ad279.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.