### PR TITLE
fix(readme): remove BIP39 checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Native android lightning wallet focused on user experience and ease of use âš¡ï¸
 - [x] Available in many languages
 - [ ] Resend failed lightning transactions
 - [x] Transaction filter
-- [ ] BIP39 passphrase
 
 **Security**
 - [x] PIN protected access


### PR DESCRIPTION
This commit removes the `BIP39` checkbox from our README as LND doesn't use BIP39 and we have no plans to support BIP39 in the immediate future