### PR TITLE
Fix  pin Animation in preferences

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -51,16 +51,14 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
     private SwitchPreference mSwHideTotalBalance;
     private ListPreference mListCurrency;
-    private Preference mAddPin;
-    private Preference mChangePin;
-
+    private Preference mPinPref;
+    
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         // Load the settings from an XML resource
         setPreferencesFromResource(R.xml.settings, rootKey);
 
-        mAddPin = findPreference("addPIN");
-        mChangePin = findPreference("changePIN");
+        mPinPref = findPreference("pinPref");
 
         // Update our current selected first currency in the MonetaryUtil
         final ListPreference listBtcUnit = findPreference("firstCurrency");
@@ -169,14 +167,20 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             }
         });
 
-        // Action when clicked on "add Pin"
-        mAddPin.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+        // Action when clicked on the pin preference
+        mPinPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 if (PrefsUtil.isWalletSetup()) {
-                    Intent intent = new Intent(getActivity(), PinSetupActivity.class);
-                    intent.putExtra(RefConstants.SETUP_MODE, PinSetupActivity.ADD_PIN);
-                    startActivity(intent);
+                    if (PrefsUtil.isPinEnabled()) {
+                        Intent intent = new Intent(getActivity(), PinSetupActivity.class);
+                        intent.putExtra(RefConstants.SETUP_MODE, PinSetupActivity.CHANGE_PIN);
+                        startActivity(intent);
+                    } else {
+                        Intent intent = new Intent(getActivity(), PinSetupActivity.class);
+                        intent.putExtra(RefConstants.SETUP_MODE, PinSetupActivity.ADD_PIN);
+                        startActivity(intent);
+                    }
                 } else {
                     Toast.makeText(getActivity(), R.string.demo_setupWalletFirst, Toast.LENGTH_LONG).show();
                 }
@@ -184,16 +188,6 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             }
         });
 
-        // Action when clicked on "change pin"
-        mChangePin.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-            @Override
-            public boolean onPreferenceClick(Preference preference) {
-                Intent intent = new Intent(getActivity(), PinSetupActivity.class);
-                intent.putExtra(RefConstants.SETUP_MODE, PinSetupActivity.CHANGE_PIN);
-                startActivity(intent);
-                return true;
-            }
-        });
 
         // Action when clicked on "reset all"
         final Preference prefResetAll = findPreference("resetAll");
@@ -386,17 +380,15 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         mListCurrency.setValue(PrefsUtil.getSecondCurrency());
         mListCurrency.setSummary(PrefsUtil.getSecondCurrency());
         createSecondCurrencyList();
-        pinOptionVisibility();
+        pinOptionText();
     }
 
-    private void pinOptionVisibility() {
+    private void pinOptionText() {
         // Display add or change pin
         if (PrefsUtil.isPinEnabled()) {
-            mAddPin.setVisible(false);
-            mChangePin.setVisible(true);
+            mPinPref.setTitle(R.string.settings_changePin);
         } else {
-            mAddPin.setVisible(true);
-            mChangePin.setVisible(false);
+            mPinPref.setTitle(R.string.settings_addPin);
         }
     }
 }

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -79,13 +79,8 @@
         app:iconSpaceReserved="false">
 
         <Preference
-            android:key="addPIN"
+            android:key="pinPref"
             android:title="@string/settings_addPin"
-            app:iconSpaceReserved="false" />
-
-        <Preference
-            android:key="changePIN"
-            android:title="@string/settings_changePin"
             app:iconSpaceReserved="false" />
 
         <SwitchPreference


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Combined add and change pin preference into one preference. This way we do not have to hide and unhide preferences depending on the state of the pin, which caused an animation to happen when switching between history and settings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.