### PR TITLE
Fix pin handling 

### DIFF
--- a/app/src/main/java/zapsolutions/zap/pin/PinFragment.java
+++ b/app/src/main/java/zapsolutions/zap/pin/PinFragment.java
@@ -217,7 +217,7 @@ public class PinFragment extends Fragment {
                     PrefsUtil.edit().putInt("numPINFails", 0)
                             .putBoolean(PrefsUtil.BIOMETRICS_PREFERRED, true).apply();
 
-                    ((PinSetupActivity) getActivity()).correctPinEntered();
+                    ((PinActivityInterface) getActivity()).correctPinEntered();
                 }
 
             }

--- a/app/src/main/java/zapsolutions/zap/setup/SetupActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/SetupActivity.java
@@ -6,13 +6,11 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
 import zapsolutions.zap.R;
-import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.pin.PinActivityInterface;
 import zapsolutions.zap.pin.PinFragment;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.RefConstants;
-import zapsolutions.zap.util.UtilFunctions;
 
 
 public class SetupActivity extends BaseAppCompatActivity implements PinActivityInterface {
@@ -42,7 +40,11 @@ public class SetupActivity extends BaseAppCompatActivity implements PinActivityI
                 showConnectChoice();
                 break;
             case CHANGE_CONNECTION:
-                showEnterPin();
+                if (PrefsUtil.isPinEnabled()) {
+                    showEnterPin();
+                } else {
+                    showConnectChoice();
+                }
                 break;
         }
     }


### PR DESCRIPTION
## Description
Fixes two problems I've encountered with optional pin
1. When reset config, do not ask for pin if not enabled
2. When using Biometrics on change pin, avoid crash by using interface instead of activity

## How Has This Been Tested?
Pixel 3, API 29

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.