### PR TITLE
Fix default address type

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/ReceiveBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/ReceiveBSDFragment.java
@@ -518,7 +518,7 @@ public class ReceiveBSDFragment extends RxBSDFragment implements UserGuardianInt
                 // generate onChain request
 
                 int addressType;
-                if (PrefsUtil.getPrefs().getString("btcAddressType", "p2psh").equals("bech32")) {
+                if (PrefsUtil.getPrefs().getString("btcAddressType", "bech32").equals("bech32")) {
                     addressType = 0;
                 } else {
                     addressType = 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the default Address type

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When doing a fresh install of the app, the settings showed bech32 as default address type.
But actually this was not true. It used the old format. Only going to the settings and selecting bech32 again really switched to bech32.
Now it really uses bech32 from the beginning on.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.