### PR TITLE
NFC Support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,8 @@
             android:name=".channelManagement.ScanNodePubKeyActivity"
             android:label="@string/channel_open"
             android:screenOrientation="portrait" />
+        <meta-data android:name="android.nfc.disable_beam_default"
+            android:value="true" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.NFC" />
 
     <application
         android:name="zapsolutions.zap.baseClasses.App"
@@ -38,6 +39,14 @@
                 <data android:scheme="bitcoin" />
                 <data android:scheme="lightning" />
 
+            </intent-filter>
+            <intent-filter>
+                <!-- Makes Zap startable from NFC Tags containing a bitcoin or lightning uri -->
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="bitcoin" />
+                <data android:scheme="lightning" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -19,7 +19,6 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.Lifecycle;
@@ -29,7 +28,6 @@ import androidx.lifecycle.ProcessLifecycleOwner;
 
 import com.github.lightningnetwork.lnd.lnrpc.PayReq;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
-import com.google.android.material.snackbar.Snackbar;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -489,13 +487,5 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
                 showError(error, duration);
             }
         });
-    }
-
-    private void showError(String message, int duration) {
-        Snackbar msg = Snackbar.make(HomeActivity.this.findViewById(R.id.mainContent), message, Snackbar.LENGTH_LONG);
-        View sbView = msg.getView();
-        sbView.setBackgroundColor(ContextCompat.getColor(HomeActivity.this, R.color.superRed));
-        msg.setDuration(duration);
-        msg.show();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -431,9 +431,9 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
     protected void onResume() {
         super.onResume();
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(
-                this, 0, new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
         if (mNfcAdapter != null) {
+            PendingIntent pendingIntent = PendingIntent.getActivity(
+                    this, 0, new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
             mNfcAdapter.enableForegroundDispatch(this, pendingIntent, NfcUtil.IntentFilters(), null);
         }
     }
@@ -466,25 +466,14 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
         InvoiceUtil.readInvoice(HomeActivity.this, compositeDisposable, invoice, new InvoiceUtil.OnReadInvoiceCompletedListener() {
             @Override
             public void onValidLightningInvoice(PayReq paymentRequest, String invoice) {
-                Intent intent = new Intent();
-                intent.putExtra("onChain", false);
-                intent.putExtra("lnPaymentRequest", paymentRequest.toByteArray());
-                intent.putExtra("lnInvoice", invoice);
                 SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
-                sendBottomSheetDialog.setArguments(intent.getExtras());
-                sendBottomSheetDialog.show(getSupportFragmentManager(), "sendBottomSheetDialog");
+                sendBottomSheetDialog.createLightningDialog(HomeActivity.this, paymentRequest, invoice);
             }
 
             @Override
             public void onValidBitcoinInvoice(String address, long amount, String message) {
-                Intent intent = new Intent();
-                intent.putExtra("onChain", true);
-                intent.putExtra("onChainAddress", address);
-                intent.putExtra("onChainAmount", amount);
-                intent.putExtra("onChainMessage", message);
                 SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
-                sendBottomSheetDialog.setArguments(intent.getExtras());
-                sendBottomSheetDialog.show(getSupportFragmentManager(), "sendBottomSheetDialog");
+                sendBottomSheetDialog.createOnChainDialog(HomeActivity.this, address, amount, message);
             }
 
             @Override

--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -435,15 +435,17 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
 
         PendingIntent pendingIntent = PendingIntent.getActivity(
                 this, 0, new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
-        if (mNfcAdapter != null)
+        if (mNfcAdapter != null) {
             mNfcAdapter.enableForegroundDispatch(this, pendingIntent, NfcUtil.IntentFilters(), null);
+        }
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        if (mNfcAdapter != null)
+        if (mNfcAdapter != null) {
             mNfcAdapter.disableForegroundDispatch(this);
+        }
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -452,7 +452,12 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
         NfcUtil.readTag(this, intent, new NfcUtil.OnNfcResponseListener() {
             @Override
             public void onSuccess(String payload) {
-                readInvoice(payload);
+                if (PrefsUtil.isWalletSetup()) {
+                    readInvoice(payload);
+                } else {
+                    ZapLog.debug(LOG_TAG, "Wallet not setup.");
+                    Toast.makeText(HomeActivity.this, R.string.demo_setupWalletFirst, Toast.LENGTH_SHORT).show();
+                }
             }
         });
     }

--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -466,14 +466,14 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
         InvoiceUtil.readInvoice(HomeActivity.this, compositeDisposable, invoice, new InvoiceUtil.OnReadInvoiceCompletedListener() {
             @Override
             public void onValidLightningInvoice(PayReq paymentRequest, String invoice) {
-                SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
-                sendBottomSheetDialog.createLightningDialog(HomeActivity.this, paymentRequest, invoice);
+                SendBSDFragment sendBSDFragment = SendBSDFragment.createLightningDialog(paymentRequest, invoice);
+                sendBSDFragment.show(getSupportFragmentManager(), "sendBottomSheetDialog");
             }
 
             @Override
             public void onValidBitcoinInvoice(String address, long amount, String message) {
-                SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
-                sendBottomSheetDialog.createOnChainDialog(HomeActivity.this, address, amount, message);
+                SendBSDFragment sendBSDFragment = SendBSDFragment.createOnChainDialog(address, amount, message);
+                sendBSDFragment.show(getSupportFragmentManager(), "sendBottomSheetDialog");
             }
 
             @Override

--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -81,7 +81,6 @@ public class LandingActivity extends BaseAppCompatActivity {
             PinScreenUtil.askForAccess(this, () -> {
                 Intent homeIntent = new Intent(this, HomeActivity.class);
                 homeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-                finishAffinity();
                 startActivity(homeIntent);
             });
 

--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -81,6 +81,10 @@ public class LandingActivity extends BaseAppCompatActivity {
             PinScreenUtil.askForAccess(this, () -> {
                 Intent homeIntent = new Intent(this, HomeActivity.class);
                 homeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                // FinishAffinity is needed here as this forces the on destroy events from previous activities to be executed before continuing.
+                finishAffinity();
+
                 startActivity(homeIntent);
             });
 

--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -3,10 +3,12 @@ package zapsolutions.zap;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
+import android.nfc.NfcAdapter;
 import android.os.Bundle;
 
 import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
+import zapsolutions.zap.util.NfcUtil;
 import zapsolutions.zap.util.PinScreenUtil;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.RefConstants;
@@ -20,12 +22,21 @@ public class LandingActivity extends BaseAppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // get the data from the URI Scheme
-        Intent intent = getIntent();
-        if (Intent.ACTION_VIEW.equals(intent.getAction())) {
-            Uri uri = intent.getData();
-            App.getAppContext().setUriSchemeData(uri.toString());
-            ZapLog.debug(LOG_TAG, "URI was detected: " + uri.toString());
+        // Save data when App was started with a task.
+        if (PrefsUtil.isWalletSetup()) {
+
+            // Zap was started from an URI link.
+            Intent intent = getIntent();
+            if (Intent.ACTION_VIEW.equals(intent.getAction())) {
+                Uri uri = intent.getData();
+                App.getAppContext().setUriSchemeData(uri.toString());
+                ZapLog.debug(LOG_TAG, "URI was detected: " + uri.toString());
+            }
+
+            // Zap was started using NFC.
+            if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
+                NfcUtil.readTag(LandingActivity.this, intent, payload -> App.getAppContext().setUriSchemeData(payload));
+            }
         }
 
 
@@ -70,6 +81,7 @@ public class LandingActivity extends BaseAppCompatActivity {
             PinScreenUtil.askForAccess(this, () -> {
                 Intent homeIntent = new Intent(this, HomeActivity.class);
                 homeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+                finishAffinity();
                 startActivity(homeIntent);
             });
 

--- a/app/src/main/java/zapsolutions/zap/SendActivity.java
+++ b/app/src/main/java/zapsolutions/zap/SendActivity.java
@@ -10,7 +10,6 @@ import com.github.lightningnetwork.lnd.lnrpc.PayReq;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import me.dm7.barcodescanner.zbar.Result;
-import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.baseClasses.BaseScannerActivity;
 import zapsolutions.zap.util.ClipBoardUtil;
 import zapsolutions.zap.util.InvoiceUtil;
@@ -21,7 +20,6 @@ public class SendActivity extends BaseScannerActivity {
     private static final String LOG_TAG = SendActivity.class.getName();
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
-    private boolean mFromURIScheme = false;
     private NfcAdapter mNfcAdapter;
 
     @Override
@@ -32,19 +30,9 @@ public class SendActivity extends BaseScannerActivity {
         mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
 
         mScannerInstructions.setText(R.string.send_scan_info);
-
-        if (App.getAppContext().getUriSchemeData() != null) {
-
-            // This activity was invoked because the app was started from an url (lightning: or bitcoin:)
-            // The url will be validated and the activity is finished before it will actually be shown.
-            String invoice = App.getAppContext().getUriSchemeData();
-            App.getAppContext().setUriSchemeData(null);
-            mFromURIScheme = true;
-            validateInvoice(invoice);
-        } else {
-            showCameraWithPermissionRequest();
-        }
+        showCameraWithPermissionRequest();
     }
+
 
     @Override
     public void onButtonPasteClick() {
@@ -74,19 +62,6 @@ public class SendActivity extends BaseScannerActivity {
                 mScannerView.resumeCameraPreview(SendActivity.this);
             }
         }, 2000);
-    }
-
-    @Override
-    protected void showError(String message, int duration) {
-        if (mFromURIScheme) {
-            Intent intent = new Intent();
-            intent.putExtra("error", message);
-            intent.putExtra("error_duration", duration);
-            setResult(1, intent);
-            finish();
-        } else {
-            super.showError(message, duration);
-        }
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/SendActivity.java
+++ b/app/src/main/java/zapsolutions/zap/SendActivity.java
@@ -1,27 +1,20 @@
 package zapsolutions.zap;
 
+import android.app.PendingIntent;
 import android.content.Intent;
+import android.nfc.NfcAdapter;
 import android.os.Bundle;
 import android.os.Handler;
 
 import com.github.lightningnetwork.lnd.lnrpc.PayReq;
-import com.github.lightningnetwork.lnd.lnrpc.PayReqString;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import me.dm7.barcodescanner.zbar.Result;
 import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.baseClasses.BaseScannerActivity;
-import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.util.ClipBoardUtil;
 import zapsolutions.zap.util.InvoiceUtil;
-import zapsolutions.zap.util.PrefsUtil;
-import zapsolutions.zap.util.RefConstants;
-import zapsolutions.zap.util.Wallet;
-import zapsolutions.zap.util.ZapLog;
+import zapsolutions.zap.util.NfcUtil;
 
 public class SendActivity extends BaseScannerActivity {
 
@@ -32,10 +25,14 @@ public class SendActivity extends BaseScannerActivity {
     private String mOnChainAddress;
     private long mOnChainInvoiceAmount;
     private String mOnChainInvoiceMessage;
+    private NfcAdapter mNfcAdapter;
 
     @Override
     public void onCreate(Bundle state) {
         super.onCreate(state);
+
+        //NFC
+        mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
 
         mScannerInstructions.setText(R.string.send_scan_info);
 
@@ -103,178 +100,35 @@ public class SendActivity extends BaseScannerActivity {
 
     private void validateInvoice(String invoice) {
 
-        mOnChainAddress = null;
-        mOnChainInvoiceAmount = 0L;
-        mOnChainInvoiceMessage = null;
-
-        if (PrefsUtil.isWalletSetup()) {
-
-            // Our wallet is setup
-
-            // Avoid index out of bounds. An invoice with less than 11 characters isn't valid.
-            if (invoice.length() < 11) {
-                showError(getResources().getString(R.string.error_notAPaymentRequest), 7000);
-                return;
+        InvoiceUtil.readInvoice(SendActivity.this, compositeDisposable, invoice, new InvoiceUtil.OnReadInvoiceCompletedListener() {
+            @Override
+            public void onValidLightningInvoice(PayReq paymentRequest, String invoice) {
+                goToLightningPaymentScreen(paymentRequest, invoice);
             }
 
-            // convert to lower case
-            String lnInvoice = invoice.toLowerCase();
-
-            // Remove the "lightning:" uri scheme if it is present, LND needs it without uri scheme
-            if (InvoiceUtil.isLightningUri(lnInvoice)) {
-                lnInvoice = lnInvoice.substring(InvoiceUtil.URI_PREFIX_LIGHTNING.length());
+            @Override
+            public void onValidBitcoinInvoice(String address, long amount, String message) {
+                goToOnChainPaymentScreen(address, amount, message);
             }
 
-            // Check if the invoice is a lightning invoice
-            if (InvoiceUtil.isLightningInvoice(lnInvoice)) {
-
-                // We have a lightning invoice
-
-                // Check if the invoice is for the same network the app is connected to
-                String lnInvoiceType = lnInvoice.substring(0, 4);
-                if (Wallet.getInstance().isTestnet()) {
-                    if (lnInvoiceType.equals(InvoiceUtil.INVOICE_PREFIX_LIGHTNING_TESTNET)) {
-                        decodeLightningInvoice(lnInvoice);
-                    } else {
-                        // Show error. Please use a TESTNET invoice.
-                        showError(getResources().getString(R.string.error_useTestnetRequest), 5000);
-                    }
-                } else {
-                    if (lnInvoiceType.equals(InvoiceUtil.INVOICE_PREFIX_LIGHTNING_MAINNET)) {
-                        decodeLightningInvoice(lnInvoice);
-                    } else {
-                        // Show error. Please use a MAINNET invoice.
-                        showError(getResources().getString(R.string.error_useMainnetRequest), 5000);
-                    }
-                }
-
-            } else {
-                // We do not have a lightning invoice... check if it is a valid bitcoin address / invoice
-
-                // Check if we have a bitcoin invoice with the "bitcoin:" uri scheme
-                if (InvoiceUtil.isBitcoinUri(invoice)) {
-
-                    // Add "//" to make it parsable for the java URI class if it is not present
-                    if (!invoice.substring(0, 10).equalsIgnoreCase(InvoiceUtil.URI_PREFIX_BITCOIN + "//")) {
-                        invoice = InvoiceUtil.URI_PREFIX_BITCOIN + "//" + invoice.substring(8);
-                    }
-
-                    URI bitcoinURI = null;
-                    try {
-                        bitcoinURI = new URI(invoice);
-
-                        mOnChainAddress = bitcoinURI.getHost();
-
-
-                        String message = null;
-
-                        // Fetch params
-                        if (bitcoinURI.getQuery() != null) {
-                            String[] valuePairs = bitcoinURI.getQuery().split("&");
-                            for (String pair : valuePairs) {
-                                String[] param = pair.split("=");
-                                if (param[0].equals("amount")) {
-                                    mOnChainInvoiceAmount = (long) (Double.parseDouble(param[1]) * 1e8);
-                                }
-                                if (param[0].equals("message")) {
-                                    mOnChainInvoiceMessage = param[1];
-                                }
-                            }
-                        }
-                        validateOnChainAddress(mOnChainAddress);
-
-                    } catch (URISyntaxException e) {
-                        ZapLog.debug(LOG_TAG, "URI could not be parsed");
-                        e.printStackTrace();
-                        showError("Error reading the bitcoin invoice", 4000);
-                    }
-
-                } else {
-                    // We also don't have a bitcoin invoice, check if the is a valid bitcoin address
-                    mOnChainAddress = invoice;
-                    validateOnChainAddress(mOnChainAddress);
-                }
-
-
+            @Override
+            public void onError(String error, int duration) {
+                showError(error, duration);
             }
-
-
-        } else {
-            // The wallet is not setup yet, go to next screen to show demo data.
-            showError(getResources().getString(R.string.demo_setupWalletFirst), 4000);
-        }
-    }
-
-    private void validateOnChainAddress(String address) {
-        if (address != null) {
-            if (Wallet.getInstance().isTestnet()) {
-                // We are on testnet
-                if (address.startsWith("m") || address.startsWith("n") || address.startsWith("2") || address.toLowerCase().startsWith("tb1")) {
-                    goToOnChainPaymentScreen();
-                } else if (address.startsWith("1") || address.startsWith("3") || address.toLowerCase().startsWith("bc1")) {
-                    // Show error. Please use a TESTNET invoice.
-                    showError(getResources().getString(R.string.error_useTestnetRequest), 5000);
-                } else {
-                    // Show error. No valid payment info.
-                    showError(getResources().getString(R.string.error_notAPaymentRequest), 7000);
-                }
-            } else {
-                // We are on mainnet
-                if (address.startsWith("1") || address.startsWith("3") || address.toLowerCase().startsWith("bc1")) {
-                    goToOnChainPaymentScreen();
-                } else if (address.startsWith("m") || address.startsWith("n") || address.startsWith("2") || address.toLowerCase().startsWith("tb1")) {
-                    showError(getResources().getString(R.string.error_useMainnetRequest), 5000);
-                } else {
-                    // Show error. No valid payment info.
-                    showError(getResources().getString(R.string.error_notAPaymentRequest), 7000);
-                }
-            }
-        } else {
-            // Show error. No valid payment info.
-            showError(getResources().getString(R.string.error_notAPaymentRequest), 7000);
-        }
-
+        });
 
     }
 
-    private void goToOnChainPaymentScreen() {
-        // Decoded successfully, go to send page.
-
+    private void goToOnChainPaymentScreen(String address, long amount, String message) {
         Intent intent = new Intent();
         intent.putExtra("onChain", true);
-        intent.putExtra("onChainAddress", mOnChainAddress);
-        intent.putExtra("onChainAmount", mOnChainInvoiceAmount);
-        intent.putExtra("onChainMessage", mOnChainInvoiceMessage);
+        intent.putExtra("onChainAddress", address);
+        intent.putExtra("onChainAmount", amount);
+        intent.putExtra("onChainMessage", message);
         setResult(1, intent);
         finish();
     }
 
-    private void decodeLightningInvoice(String invoice) {
-        PayReqString decodePaymentRequest = PayReqString.newBuilder()
-                .setPayReq(invoice)
-                .build();
-
-        compositeDisposable.add(LndConnection.getInstance().getLightningService().decodePayReq(decodePaymentRequest)
-                .timeout(RefConstants.TIMEOUT_SHORT, TimeUnit.SECONDS)
-                .subscribe(paymentRequest -> {
-                    ZapLog.debug(LOG_TAG, paymentRequest.toString());
-
-                    if (paymentRequest.getTimestamp() + paymentRequest.getExpiry() < System.currentTimeMillis() / 1000) {
-                        // Show error: payment request expired.
-                        showError(getResources().getString(R.string.error_paymentRequestExpired), 3000);
-                    } else if (paymentRequest.getNumSatoshis() == 0) {
-                        // Disable 0 sat invoices
-                        showError(getResources().getString(R.string.error_notAPaymentRequest), 7000);
-                    } else {
-                        // Decoded successfully, go to send page.
-                        goToLightningPaymentScreen(paymentRequest, invoice);
-                    }
-                }, throwable -> {
-                    // If LND can't decode the payment request, show the error LND throws (always english)
-                    runOnUiThread(() -> showError(throwable.getMessage(), 3000));
-                    ZapLog.debug(LOG_TAG, throwable.getMessage());
-                }));
-    }
 
     private void goToLightningPaymentScreen(PayReq paymentRequest, String invoice) {
         Intent intent = new Intent();
@@ -285,4 +139,26 @@ public class SendActivity extends BaseScannerActivity {
         finish();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                this, 0, new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
+        if (mNfcAdapter != null)
+            mNfcAdapter.enableForegroundDispatch(this, pendingIntent, NfcUtil.IntentFilters(), null);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (mNfcAdapter != null)
+            mNfcAdapter.disableForegroundDispatch(this);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        NfcUtil.readTag(this, intent, this::validateInvoice);
+    }
 }

--- a/app/src/main/java/zapsolutions/zap/SendActivity.java
+++ b/app/src/main/java/zapsolutions/zap/SendActivity.java
@@ -22,9 +22,6 @@ public class SendActivity extends BaseScannerActivity {
 
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
     private boolean mFromURIScheme = false;
-    private String mOnChainAddress;
-    private long mOnChainInvoiceAmount;
-    private String mOnChainInvoiceMessage;
     private NfcAdapter mNfcAdapter;
 
     @Override
@@ -145,15 +142,17 @@ public class SendActivity extends BaseScannerActivity {
 
         PendingIntent pendingIntent = PendingIntent.getActivity(
                 this, 0, new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
-        if (mNfcAdapter != null)
+        if (mNfcAdapter != null) {
             mNfcAdapter.enableForegroundDispatch(this, pendingIntent, NfcUtil.IntentFilters(), null);
+        }
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        if (mNfcAdapter != null)
+        if (mNfcAdapter != null) {
             mNfcAdapter.disableForegroundDispatch(this);
+        }
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/baseClasses/BaseAppCompatActivity.java
+++ b/app/src/main/java/zapsolutions/zap/baseClasses/BaseAppCompatActivity.java
@@ -2,11 +2,16 @@ package zapsolutions.zap.baseClasses;
 
 import android.content.Context;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.WindowManager;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
+import com.google.android.material.snackbar.Snackbar;
+
+import zapsolutions.zap.R;
 import zapsolutions.zap.util.LocaleUtil;
 import zapsolutions.zap.util.PrefsUtil;
 
@@ -54,5 +59,13 @@ public abstract class BaseAppCompatActivity extends AppCompatActivity {
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    protected void showError(String message, int duration) {
+        Snackbar msg = Snackbar.make(findViewById(android.R.id.content), message, Snackbar.LENGTH_LONG);
+        View sbView = msg.getView();
+        sbView.setBackgroundColor(ContextCompat.getColor(this, R.color.superRed));
+        msg.setDuration(duration);
+        msg.show();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/baseClasses/BaseScannerActivity.java
+++ b/app/src/main/java/zapsolutions/zap/baseClasses/BaseScannerActivity.java
@@ -16,8 +16,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 
-import com.google.android.material.snackbar.Snackbar;
-
 import java.util.ArrayList;
 
 import me.dm7.barcodescanner.zbar.BarcodeFormat;
@@ -147,14 +145,6 @@ public abstract class BaseScannerActivity extends BaseAppCompatActivity implemen
         if (ab != null) {
             ab.setDisplayHomeAsUpEnabled(true);
         }
-    }
-
-    protected void showError(String message, int duration) {
-        Snackbar msg = Snackbar.make(findViewById(R.id.content_frame), message, Snackbar.LENGTH_LONG);
-        View sbView = msg.getView();
-        sbView.setBackgroundColor(ContextCompat.getColor(this, R.color.superRed));
-        msg.setDuration(duration);
-        msg.show();
     }
 
     protected void showCameraView() {

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -47,6 +47,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import zapsolutions.zap.R;
+import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.channelManagement.ManageChannelsActivity;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.customView.LightningFeeView;
@@ -553,6 +554,25 @@ public class SendBSDFragment extends RxBSDFragment {
         });
 
         return view;
+    }
+
+    public void createLightningDialog(BaseAppCompatActivity activity, PayReq paymentRequest, String invoice) {
+        Intent intent = new Intent();
+        intent.putExtra("onChain", false);
+        intent.putExtra("lnPaymentRequest", paymentRequest.toByteArray());
+        intent.putExtra("lnInvoice", invoice);
+        this.setArguments(intent.getExtras());
+        this.show(activity.getSupportFragmentManager(), "sendBottomSheetDialog");
+    }
+
+    public void createOnChainDialog(BaseAppCompatActivity activity, String address, long amount, String message) {
+        Intent intent = new Intent();
+        intent.putExtra("onChain", true);
+        intent.putExtra("onChainAddress", address);
+        intent.putExtra("onChainAmount", amount);
+        intent.putExtra("onChainMessage", message);
+        this.setArguments(intent.getExtras());
+        this.show(activity.getSupportFragmentManager(), "sendBottomSheetDialog");
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -47,7 +47,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import zapsolutions.zap.R;
-import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.channelManagement.ManageChannelsActivity;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.customView.LightningFeeView;
@@ -556,23 +555,25 @@ public class SendBSDFragment extends RxBSDFragment {
         return view;
     }
 
-    public void createLightningDialog(BaseAppCompatActivity activity, PayReq paymentRequest, String invoice) {
+    public static SendBSDFragment createLightningDialog(PayReq paymentRequest, String invoice) {
         Intent intent = new Intent();
         intent.putExtra("onChain", false);
         intent.putExtra("lnPaymentRequest", paymentRequest.toByteArray());
         intent.putExtra("lnInvoice", invoice);
-        this.setArguments(intent.getExtras());
-        this.show(activity.getSupportFragmentManager(), "sendBottomSheetDialog");
+        SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
+        sendBottomSheetDialog.setArguments(intent.getExtras());
+        return sendBottomSheetDialog;
     }
 
-    public void createOnChainDialog(BaseAppCompatActivity activity, String address, long amount, String message) {
+    public static SendBSDFragment createOnChainDialog(String address, long amount, String message) {
         Intent intent = new Intent();
         intent.putExtra("onChain", true);
         intent.putExtra("onChainAddress", address);
         intent.putExtra("onChainAmount", amount);
         intent.putExtra("onChainMessage", message);
-        this.setArguments(intent.getExtras());
-        this.show(activity.getSupportFragmentManager(), "sendBottomSheetDialog");
+        SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
+        sendBottomSheetDialog.setArguments(intent.getExtras());
+        return sendBottomSheetDialog;
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
@@ -340,7 +340,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         super.onActivityResult(requestCode, resultCode, data);
         // check if the request code is same as what is passed. Here it is 1
         if (requestCode == 1) {
-            // This gets executed if the a vaild payment request was scanned or pasted
+            // This gets executed if a valid payment request was scanned or pasted
             if (data != null) {
                 if (data.getExtras().getString("error") == null) {
                     // forward data to send fragment

--- a/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
@@ -275,17 +275,6 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
             }
         }
 
-        // if the wallet is not setup we still want to show the wallet and an error if a payment url was used.
-        if (!PrefsUtil.isWalletSetup()) {
-            mWalletConnectedLayout.setVisibility(View.VISIBLE);
-            mLoadingWalletLayout.setVisibility(View.GONE);
-            if (App.getAppContext().getUriSchemeData() != null) {
-                Intent intent = new Intent(getActivity(), SendActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-                startActivityForResult(intent, 1);
-            }
-        }
-
         return view;
     }
 
@@ -298,14 +287,6 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
 
             // Fetch the current balance and info from LND
             Wallet.getInstance().fetchBalanceFromLND();
-        }
-
-        // check if we have an URI Scheme present. If there is one, start the send activity,
-        // which will then immediately start to validate it.
-        if (App.getAppContext().getUriSchemeData() != null) {
-            Intent intent = new Intent(getActivity(), SendActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-            startActivityForResult(intent, 1);
         }
     }
 

--- a/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
@@ -1,8 +1,23 @@
 package zapsolutions.zap.util;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 
+import com.github.lightningnetwork.lnd.lnrpc.PayReq;
+import com.github.lightningnetwork.lnd.lnrpc.PayReqString;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import zapsolutions.zap.R;
+import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
+
 public class InvoiceUtil {
+    private static final String LOG_TAG = InvoiceUtil.class.getName();
 
     public static String URI_PREFIX_LIGHTNING = "lightning:";
     public static String URI_PREFIX_BITCOIN = "bitcoin:";
@@ -42,11 +57,169 @@ public class InvoiceUtil {
         return hasPrefix(INVOICE_PREFIX_LIGHTNING_MAINNET, data) || hasPrefix(INVOICE_PREFIX_LIGHTNING_TESTNET, data);
     }
 
+    public static void readInvoice(Context ctx, CompositeDisposable compositeDisposable, String data, OnReadInvoiceCompletedListener listener) {
+
+        // Avoid index out of bounds. An Request with less than 11 characters isn't valid.
+        if (data.length() < 11) {
+            listener.onError(ctx.getString(R.string.error_notAPaymentRequest), 7000);
+            return;
+        }
+
+        // convert to lower case
+        String lnInvoice = data.toLowerCase();
+
+        // Remove the "lightning:" uri scheme if it is present, LND needs it without uri scheme
+        if (InvoiceUtil.isLightningUri(lnInvoice)) {
+            lnInvoice = lnInvoice.substring(InvoiceUtil.URI_PREFIX_LIGHTNING.length());
+        }
+
+        // Check if the invoice is a lightning invoice
+        if (InvoiceUtil.isLightningInvoice(lnInvoice)) {
+
+            // We have a lightning invoice
+
+            // Check if the invoice is for the same network the app is connected to
+            String lnInvoiceType = lnInvoice.substring(0, 4);
+            if (Wallet.getInstance().isTestnet()) {
+                if (lnInvoiceType.equals(InvoiceUtil.INVOICE_PREFIX_LIGHTNING_TESTNET)) {
+                    decodeLightningInvoice(ctx, listener, lnInvoice, compositeDisposable);
+                } else {
+                    // Show error. Please use a TESTNET invoice.
+                    listener.onError(ctx.getString(R.string.error_useTestnetRequest), 5000);
+                }
+            } else {
+                if (lnInvoiceType.equals(InvoiceUtil.INVOICE_PREFIX_LIGHTNING_MAINNET)) {
+                    decodeLightningInvoice(ctx, listener, lnInvoice, compositeDisposable);
+                } else {
+                    // Show error. Please use a MAINNET invoice.
+                    listener.onError(ctx.getString(R.string.error_useMainnetRequest), 5000);
+                }
+            }
+
+        } else {
+            // We do not have a lightning invoice... check if it is a valid bitcoin address / invoice
+
+            // Check if we have a bitcoin invoice with the "bitcoin:" uri scheme
+            if (InvoiceUtil.isBitcoinUri(data)) {
+
+                // Add "//" to make it parsable for the java URI class if it is not present
+                if (!data.substring(0, 10).equalsIgnoreCase(InvoiceUtil.URI_PREFIX_BITCOIN + "//")) {
+                    data = InvoiceUtil.URI_PREFIX_BITCOIN + "//" + data.substring(8);
+                }
+
+                URI bitcoinURI = null;
+                try {
+                    bitcoinURI = new URI(data);
+
+                    String onChainAddress = bitcoinURI.getHost();
+
+                    long onChainInvoiceAmount = 0L;
+                    String onChainInvoiceMessage = null;
+
+                    // Fetch params
+                    if (bitcoinURI.getQuery() != null) {
+                        String[] valuePairs = bitcoinURI.getQuery().split("&");
+                        for (String pair : valuePairs) {
+                            String[] param = pair.split("=");
+                            if (param[0].equals("amount")) {
+                                onChainInvoiceAmount = (long) (Double.parseDouble(param[1]) * 1e8);
+                            }
+                            if (param[0].equals("message")) {
+                                onChainInvoiceMessage = param[1];
+                            }
+                        }
+                    }
+                    validateOnChainAddress(ctx, listener, onChainAddress, onChainInvoiceAmount, onChainInvoiceMessage);
+
+                } catch (URISyntaxException e) {
+                    ZapLog.debug(LOG_TAG, "URI could not be parsed");
+                    e.printStackTrace();
+                    listener.onError("Invalid Bitcoin Request", 5000);
+                }
+
+            } else {
+                // We also don't have a bitcoin invoice, check if the data is a valid bitcoin address
+                validateOnChainAddress(ctx, listener, data, 0L, null);
+            }
+
+        }
+
+    }
+
+    private static void validateOnChainAddress(Context ctx, OnReadInvoiceCompletedListener listener, String address, long amount, String message) {
+        if (address != null) {
+            if (Wallet.getInstance().isTestnet()) {
+                // We are on testnet
+                if (address.startsWith("m") || address.startsWith("n") || address.startsWith("2") || address.toLowerCase().startsWith("tb1")) {
+                    listener.onValidBitcoinInvoice(address, amount, message);
+                } else if (address.startsWith("1") || address.startsWith("3") || address.toLowerCase().startsWith("bc1")) {
+                    // Show error. Please use a TESTNET invoice.
+                    listener.onError(ctx.getString(R.string.error_useTestnetRequest), 5000);
+                } else {
+                    // Show error. No valid payment info.
+                    listener.onError(ctx.getString(R.string.error_notAPaymentRequest), 7000);
+                }
+            } else {
+                // We are on mainnet
+                if (address.startsWith("1") || address.startsWith("3") || address.toLowerCase().startsWith("bc1")) {
+                    listener.onValidBitcoinInvoice(address, amount, message);
+                } else if (address.startsWith("m") || address.startsWith("n") || address.startsWith("2") || address.toLowerCase().startsWith("tb1")) {
+                    listener.onError(ctx.getString(R.string.error_useMainnetRequest), 5000);
+                } else {
+                    // Show error. No valid payment info.
+                    listener.onError(ctx.getString(R.string.error_notAPaymentRequest), 7000);
+                }
+            }
+        } else {
+            // Show error. No valid payment info.
+            listener.onError(ctx.getString(R.string.error_notAPaymentRequest), 7000);
+        }
+    }
+
+    private static void decodeLightningInvoice(Context ctx, OnReadInvoiceCompletedListener listener, String invoice, CompositeDisposable compositeDisposable) {
+        PayReqString decodePaymentRequest = PayReqString.newBuilder()
+                .setPayReq(invoice)
+                .build();
+
+        compositeDisposable.add(LndConnection.getInstance().getLightningService().decodePayReq(decodePaymentRequest)
+                .timeout(RefConstants.TIMEOUT_SHORT, TimeUnit.SECONDS)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(paymentRequest -> {
+                    ZapLog.debug(LOG_TAG, paymentRequest.toString());
+
+                    if (paymentRequest.getTimestamp() + paymentRequest.getExpiry() < System.currentTimeMillis() / 1000) {
+                        // Show error: payment request expired.
+                        listener.onError(ctx.getString(R.string.error_paymentRequestExpired), 3000);
+                    } else if (paymentRequest.getNumSatoshis() == 0) {
+                        // Disable 0 sat invoices
+                        listener.onError(ctx.getString(R.string.error_notAPaymentRequest), 7000);
+                    } else {
+                        // Decoded successfully, go to send page.
+
+                        listener.onValidLightningInvoice(paymentRequest, invoice);
+                    }
+                }, throwable -> {
+                    // If LND can't decode the payment request, show the error LND throws (always english)
+                    listener.onError(throwable.getMessage(), 5000);
+
+                    ZapLog.debug(LOG_TAG, throwable.getMessage());
+                }));
+
+    }
+
     private static boolean hasPrefix(@NonNull String prefix, @NonNull String data) {
         if (data.isEmpty() || data.length() < prefix.length()) {
             return false;
         }
 
         return data.substring(0, prefix.length()).equalsIgnoreCase(prefix);
+    }
+
+    public interface OnReadInvoiceCompletedListener {
+        void onValidLightningInvoice(PayReq paymentRequest, String invoice);
+
+        void onValidBitcoinInvoice(String address, long amount, String message);
+
+        void onError(String error, int duration);
     }
 }

--- a/app/src/main/java/zapsolutions/zap/util/NfcUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/NfcUtil.java
@@ -1,0 +1,101 @@
+package zapsolutions.zap.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.nfc.NdefMessage;
+import android.nfc.NdefRecord;
+import android.nfc.NfcAdapter;
+import android.nfc.tech.Ndef;
+import android.os.Parcelable;
+import android.widget.Toast;
+
+import java.util.Arrays;
+
+import zapsolutions.zap.R;
+
+public class NfcUtil {
+
+    private static final String LOG_TAG = NfcUtil.class.getName();
+
+    /**
+     * This function reads the content of an NFC Ndef Tag.
+     * As we want to read all NFC Tags while zap is open and a specific Activities (done with ForegroundDispatch),
+     * we have to make sure that we validate the tag type properly in this function.
+     * The filters from the manifest only apply to a tag that is read while the app is not in foreground
+     * or at an activity that does not do any foreground dispatching.
+     *
+     * @param ctx      Context.
+     * @param intent   The Intent
+     * @param listener listener which provides the payload in its onSuccess function
+     */
+    public static void readTag(Context ctx, Intent intent, OnNfcResponseListener listener) {
+        String action = intent.getAction();
+        ZapLog.debug(LOG_TAG, "onNewIntent: " + action);
+        if (action != null) {
+            if (action.equals(NfcAdapter.ACTION_TAG_DISCOVERED) || action.equals(NfcAdapter.ACTION_NDEF_DISCOVERED)) {
+
+                Parcelable[] rawMessages =
+                        intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES);
+                if (rawMessages != null) {
+                    NdefMessage[] messages = new NdefMessage[rawMessages.length];
+                    for (int i = 0; i < rawMessages.length; i++) {
+                        messages[i] = (NdefMessage) rawMessages[i];
+                    }
+                    // Process the messages array.
+                    NdefMessage message = messages[0];
+
+                    ZapLog.debug(LOG_TAG, "Ndef message: " + message);
+                    NdefRecord[] records = message.getRecords();
+                    ZapLog.debug(LOG_TAG, "Ndef record: " + records[0]);
+                    if (records[0].getTnf() == NdefRecord.TNF_WELL_KNOWN) {
+                        if (Arrays.equals(records[0].getType(), NdefRecord.RTD_URI)) {
+                            byte[] rawPayload = records[0].getPayload();
+                            StringBuilder sb = new StringBuilder();
+                            for (int i = 1; i < rawPayload.length; i++) {
+                                sb.append((char) rawPayload[i]);
+                            }
+                            String payload = sb.toString();
+                            ZapLog.debug(LOG_TAG, "Ndef payload: " + payload);
+                            if (PrefsUtil.isWalletSetup()){
+                                listener.onSuccess(payload);
+                            } else {
+                                ZapLog.debug(LOG_TAG, "Wallet not setup.");
+                                Toast.makeText(ctx, R.string.demo_setupWalletFirst, Toast.LENGTH_SHORT).show();
+                            }
+                        } else {
+                            ZapLog.debug(LOG_TAG, "This NdefRecord is not supported");
+                            showNotSupportedToast(ctx);
+                        }
+                    } else {
+                        ZapLog.debug(LOG_TAG, "This NdefRecord type name field (TNF) is not supported");
+                        showNotSupportedToast(ctx);
+                    }
+
+                } else {
+                    ZapLog.debug(LOG_TAG, "Tag message is empty");
+                    showNotSupportedToast(ctx);
+                }
+            }
+        }
+    }
+
+    public static IntentFilter[] IntentFilters() {
+        IntentFilter tagDetected = new IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED);
+        IntentFilter ndefDetected = new IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED);
+        IntentFilter techDetected = new IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED);
+        return new IntentFilter[]{techDetected, tagDetected, ndefDetected};
+    }
+
+    public static String[][] TechFilters() {
+        return new String[][]{new String[]{Ndef.class.getName()}};
+    }
+
+    private static void showNotSupportedToast(Context ctx) {
+        Toast.makeText(ctx, R.string.nfc_type_not_supported, Toast.LENGTH_SHORT).show();
+    }
+
+    public interface OnNfcResponseListener {
+        void onSuccess(String payload);
+    }
+}

--- a/app/src/main/java/zapsolutions/zap/util/NfcUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/NfcUtil.java
@@ -57,12 +57,7 @@ public class NfcUtil {
                             }
                             String payload = sb.toString();
                             ZapLog.debug(LOG_TAG, "Ndef payload: " + payload);
-                            if (PrefsUtil.isWalletSetup()) {
-                                listener.onSuccess(payload);
-                            } else {
-                                ZapLog.debug(LOG_TAG, "Wallet not setup.");
-                                Toast.makeText(ctx, R.string.demo_setupWalletFirst, Toast.LENGTH_SHORT).show();
-                            }
+                            listener.onSuccess(payload);
                         } else {
                             ZapLog.debug(LOG_TAG, "This NdefRecord is not supported");
                             showNotSupportedToast(ctx);

--- a/app/src/main/java/zapsolutions/zap/util/NfcUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/NfcUtil.java
@@ -57,7 +57,7 @@ public class NfcUtil {
                             }
                             String payload = sb.toString();
                             ZapLog.debug(LOG_TAG, "Ndef payload: " + payload);
-                            if (PrefsUtil.isWalletSetup()){
+                            if (PrefsUtil.isWalletSetup()) {
                                 listener.onSuccess(payload);
                             } else {
                                 ZapLog.debug(LOG_TAG, "Wallet not setup.");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,4 +339,6 @@
     <string name="tor_fdroid_info">If Zap fails to find Orbot in the next step, make sure you have added and enabled the Guardian Project repository in F-Droid and try again.</string>
     <string name="tor_download_fdroid">You need an App Store to download Orbot. Please first download F-Droid.</string>
     <string name="tor_add_repo">Add Repository</string>
+
+    <string name="nfc_type_not_supported">Unsupported NFC type</string>
 </resources>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support for NFC.
It is now possible to read NFC Ndef Tags. (If app is not started, it will be opened)

The NFC Messages Zap reacts to are of Type URI.
It can read both, "bitcoin:" and "lightning:"

This PR also refactors the Send activity and moves some logic to the InvoiceUtil to improve the URI process flow. Now it is no longer required to start the SendActivity to process the URI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
NFC can further improve usability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9 and my S6

I used these tags:
https://www.amazon.de/Schl%C3%BCssel-Anh%C3%A4nger-programmierbar-NFC-Leseger%C3%A4ten-Android-Smartphones-RFID-Schl%C3%BCssel/dp/B075XMP8PN/ref=sr_1_8?__mk_de_DE=%C3%85M%C3%85%C5%BD%C3%95%C3%91&keywords=nfc+tag&qid=1579354869&sr=8-8

Interoperabillity was also tested with Wallet Of Satoshi

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.