### PR TITLE
Make wallets UUID based and comparable by name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "zapsolutions.zap"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 18
-        versionName "0.2.12-alpha"
+        versionCode 17
+        versionName "0.2.11-alpha"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         setProperty("archivesBaseName", "zap-android-" + versionName + "(" + versionCode + ")")
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "zapsolutions.zap"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 17
-        versionName "0.2.11-alpha"
+        versionCode 18
+        versionName "0.2.12-alpha"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         setProperty("archivesBaseName", "zap-android-" + versionName + "(" + versionCode + ")")
     }

--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -80,10 +80,10 @@ public class LandingActivity extends BaseAppCompatActivity {
 
     private void convertWalletNameToUUID() {
         if (PrefsUtil.isWalletSetup()) {
-            if (WalletConfigsManager.getInstance().getWalletConfigsJson().getConnections().size() > 0) {
-                WalletConfig config = WalletConfigsManager.getInstance().getWalletConfigsJson().getConnections().get(0);
+            if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
+                WalletConfig config = (WalletConfig)WalletConfigsManager.getInstance().getWalletConfigsJson().getConnections().toArray()[0];
                 WalletConfigsManager.getInstance().removeAllWalletConfigs();
-                String id = WalletConfigsManager.getInstance().addWalletConfig(config.getHost(), config.getType(), config.getHost(), config.getPort(), config.getCert(), config.getMacaroon());
+                String id = WalletConfigsManager.getInstance().addWalletConfig(config.getHost(), config.getType(), config.getHost(), config.getPort(), config.getCert(), config.getMacaroon()).getId();
                 try {
                     WalletConfigsManager.getInstance().apply();
                 } catch (Exception e) {

--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -81,7 +81,7 @@ public class LandingActivity extends BaseAppCompatActivity {
     private void convertWalletNameToUUID() {
         if (PrefsUtil.isWalletSetup()) {
             if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
-                WalletConfig config = (WalletConfig)WalletConfigsManager.getInstance().getWalletConfigsJson().getConnections().toArray()[0];
+                WalletConfig config = (WalletConfig) WalletConfigsManager.getInstance().getWalletConfigsJson().getConnections().toArray()[0];
                 WalletConfigsManager.getInstance().removeAllWalletConfigs();
                 String id = WalletConfigsManager.getInstance().addWalletConfig(config.getHost(), config.getType(), config.getHost(), config.getPort(), config.getCert(), config.getMacaroon()).getId();
                 try {
@@ -90,13 +90,9 @@ public class LandingActivity extends BaseAppCompatActivity {
                     e.printStackTrace();
                 }
                 PrefsUtil.edit().putString(PrefsUtil.CURRENT_WALLET_CONFIG, id).commit();
-                enterWallet();
-            } else {
-                enterWallet();
             }
-        } else {
-            enterWallet();
         }
+        enterWallet();
     }
 
     private void enterWallet() {

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
@@ -1,5 +1,7 @@
 package zapsolutions.zap.connection.manageWalletConfigs;
 
+import androidx.annotation.Nullable;
+
 import zapsolutions.zap.connection.RemoteConfiguration;
 
 public class WalletConfig extends RemoteConfiguration implements Comparable<WalletConfig> {
@@ -46,9 +48,30 @@ public class WalletConfig extends RemoteConfiguration implements Comparable<Wall
 
     public boolean isLocal() {return this.type.equals(WALLET_TYPE_LOCAL);}
 
+    public WalletConfig (String id) {
+        this.id = id;
+    }
+
     @Override
     public int compareTo(WalletConfig walletConfig) {
         WalletConfig other = walletConfig;
         return this.getAlias().compareTo(other.getAlias());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        WalletConfig walletConfig = (WalletConfig) obj;
+        return walletConfig.getId().equals(this.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.id.hashCode();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
@@ -2,12 +2,23 @@ package zapsolutions.zap.connection.manageWalletConfigs;
 
 import zapsolutions.zap.connection.RemoteConfiguration;
 
-public class WalletConfig extends RemoteConfiguration {
+public class WalletConfig extends RemoteConfiguration implements Comparable<WalletConfig> {
 
+    public static final String WALLET_TYPE_LOCAL = "local";
+    public static final String WALLET_TYPE_REMOTE = "remote";
+
+    private String id;
     private String alias;
     private String type;
     private String cert;
 
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getAlias() {
         return this.alias;
@@ -33,4 +44,11 @@ public class WalletConfig extends RemoteConfiguration {
         this.cert = cert;
     }
 
+    public boolean isLocal() {return this.type.equals(WALLET_TYPE_LOCAL);}
+
+    @Override
+    public int compareTo(WalletConfig walletConfig) {
+        WalletConfig other = walletConfig;
+        return this.getAlias().compareTo(other.getAlias());
+    }
 }

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
@@ -18,10 +18,6 @@ public class WalletConfig extends RemoteConfiguration implements Comparable<Wall
         return this.id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public String getAlias() {
         return this.alias;
     }

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfig.java
@@ -72,6 +72,10 @@ public class WalletConfig extends RemoteConfiguration implements Comparable<Wall
 
     @Override
     public int hashCode() {
-        return this.id.hashCode();
+        if (this.id !=null) {
+            return this.id.hashCode();
+        } else {
+            return this.alias.hashCode();
+        }
     }
 }

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsJson.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsJson.java
@@ -4,20 +4,19 @@ import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.util.List;
+import java.util.Set;
 
 public class WalletConfigsJson {
 
     @SerializedName("connections")
-    List<WalletConfig> mConnections;
+    Set<WalletConfig> mConnections;
 
-    public WalletConfig getConnection(@NonNull String id) {
+    public WalletConfig getConnectionById(@NonNull String id) {
         for (WalletConfig walletConnectionConfig : mConnections) {
             if (walletConnectionConfig.getId().equals(id)) {
                 return walletConnectionConfig;
             }
         }
-
         return null;
     }
 
@@ -27,60 +26,44 @@ public class WalletConfigsJson {
                 return walletConnectionConfig;
             }
         }
-
         return null;
     }
 
-    public List<WalletConfig> getConnections() {
+    public Set<WalletConfig> getConnections() {
         return mConnections;
     }
 
-    boolean doesWalletConfigExist(String id) {
-        return getConnection(id) != null;
+    boolean doesWalletConfigExist(@NonNull WalletConfig walletConfig) {
+        return mConnections.contains(walletConfig);
     }
 
-    void addWallet(@NonNull WalletConfig walletConfig) {
+    boolean addWallet(@NonNull WalletConfig walletConfig) {
+        return mConnections.add(walletConfig);
+    }
 
-        // Test if it already exist
-        if (doesWalletConfigExist(walletConfig.getId())) {
-            int tempIndex = getWalletConfigIndex(walletConfig.getId());
-            // It exists, replace it.
-            mConnections.set(tempIndex, walletConfig);
-        } else {
-            // Nothing exist yet, create a new one.
+    boolean removeWalletConfig(WalletConfig walletConfig) {
+        return mConnections.remove(walletConfig);
+    }
+
+    boolean updateWalletConfig(WalletConfig walletConfig) {
+        if (doesWalletConfigExist(walletConfig)) {
+            mConnections.remove(walletConfig);
             mConnections.add(walletConfig);
-        }
-
-    }
-
-
-    public boolean removeWalletConfig(String id) {
-
-        if (doesWalletConfigExist(id)) {
-            int tempIndex = getWalletConfigIndex(id);
-            mConnections.remove(tempIndex);
             return true;
+        } else {
+            return false;
         }
-        return false;
     }
 
-    public boolean renameWalletConfig(String id, String newAlias) {
-        if (doesWalletConfigExist(id)) {
-            int tempIndex = getWalletConfigIndex(id);
-            mConnections.get(tempIndex).setAlias(newAlias);
+    boolean renameWalletConfig(WalletConfig walletConfig, @NonNull String newAlias) {
+        if (doesWalletConfigExist(walletConfig)) {
+            WalletConfig tempConfig = getConnectionById(walletConfig.getId());
+            tempConfig.setAlias(newAlias);
+            mConnections.remove(walletConfig);
+            mConnections.add(tempConfig);
             return true;
+        } else {
+            return false;
         }
-        return false;
-    }
-
-    private int getWalletConfigIndex(@NonNull String id) {
-        int tempIndex = -1;
-        for (WalletConfig tempConfig : mConnections) {
-            if (tempConfig.getId().equals(id)) {
-                tempIndex = mConnections.indexOf(tempConfig);
-                break;
-            }
-        }
-        return tempIndex;
     }
 }

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsJson.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsJson.java
@@ -11,7 +11,17 @@ public class WalletConfigsJson {
     @SerializedName("connections")
     List<WalletConfig> mConnections;
 
-    public WalletConfig getConnection(@NonNull String alias) {
+    public WalletConfig getConnection(@NonNull String id) {
+        for (WalletConfig walletConnectionConfig : mConnections) {
+            if (walletConnectionConfig.getId().equals(id)) {
+                return walletConnectionConfig;
+            }
+        }
+
+        return null;
+    }
+
+    public WalletConfig getConnectionByAlias(@NonNull String alias) {
         for (WalletConfig walletConnectionConfig : mConnections) {
             if (walletConnectionConfig.getAlias().toLowerCase().equals(alias.toLowerCase())) {
                 return walletConnectionConfig;
@@ -21,15 +31,19 @@ public class WalletConfigsJson {
         return null;
     }
 
-    boolean doesWalletConfigExist(String alias) {
-        return getConnection(alias) != null;
+    public List<WalletConfig> getConnections() {
+        return mConnections;
     }
 
-    void addWalletConfig(@NonNull WalletConfig walletConfig) {
+    boolean doesWalletConfigExist(String id) {
+        return getConnection(id) != null;
+    }
+
+    void addWallet(@NonNull WalletConfig walletConfig) {
 
         // Test if it already exist
-        if (doesWalletConfigExist(walletConfig.getAlias())) {
-            int tempIndex = getWalletIndex(walletConfig.getAlias());
+        if (doesWalletConfigExist(walletConfig.getId())) {
+            int tempIndex = getWalletConfigIndex(walletConfig.getId());
             // It exists, replace it.
             mConnections.set(tempIndex, walletConfig);
         } else {
@@ -40,33 +54,29 @@ public class WalletConfigsJson {
     }
 
 
-    public boolean removeConnection(String alias) {
+    public boolean removeWalletConfig(String id) {
 
-        if (doesWalletConfigExist(alias)) {
-            int tempIndex = getWalletIndex(alias);
+        if (doesWalletConfigExist(id)) {
+            int tempIndex = getWalletConfigIndex(id);
             mConnections.remove(tempIndex);
             return true;
         }
         return false;
     }
 
-    public boolean renameConnection(String oldAlias, String newAlias) {
-        if (doesWalletConfigExist(oldAlias)) {
-            if (doesWalletConfigExist(newAlias) && !newAlias.toLowerCase().equals(oldAlias.toLowerCase())) {
-                // We cannot rename it to an already existing wallet.
-                return false;
-            }
-            int tempIndex = getWalletIndex(oldAlias);
+    public boolean renameWalletConfig(String id, String newAlias) {
+        if (doesWalletConfigExist(id)) {
+            int tempIndex = getWalletConfigIndex(id);
             mConnections.get(tempIndex).setAlias(newAlias);
             return true;
         }
         return false;
     }
 
-    private int getWalletIndex(@NonNull String alias) {
+    private int getWalletConfigIndex(@NonNull String id) {
         int tempIndex = -1;
         for (WalletConfig tempConfig : mConnections) {
-            if (tempConfig.getAlias().toLowerCase().equals(alias.toLowerCase())) {
+            if (tempConfig.getId().equals(id)) {
                 tempIndex = mConnections.indexOf(tempConfig);
                 break;
             }

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsManager.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsManager.java
@@ -14,6 +14,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -21,16 +25,17 @@ import javax.crypto.NoSuchPaddingException;
 
 import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.util.PrefsUtil;
+import zapsolutions.zap.util.ZapLog;
 
 /**
  * This SINGLETON class is used to load and save configurations for wallets.
- * Multiple wallets can exist simultaneously, but each alias (wallet name) is only allowed to exist once.
+ * Multiple wallets can exist simultaneously.
  * <p>
  * The wallet configurations are stored encrypted in the default shared preferences.
  */
 public class WalletConfigsManager {
 
-    public static final String DEFAULT_WALLET_NAME = "Default Wallet";
+    public static final String DEFAULT_LOCAL_WALLET_NAME = "Zap-Android";
     private static final String LOG_TAG = WalletConfigsManager.class.getName();
     private static WalletConfigsManager mInstance;
     private WalletConfigsJson mWalletConfigsJson;
@@ -49,11 +54,11 @@ public class WalletConfigsManager {
         if (isValidJson(decrypted)) {
             mWalletConfigsJson = new Gson().fromJson(decrypted, WalletConfigsJson.class);
         } else {
-            createEmptyWalletConfigsJson();
+            mWalletConfigsJson = createEmptyWalletConfigsJson();
         }
 
         if (mWalletConfigsJson == null) {
-            createEmptyWalletConfigsJson();
+            mWalletConfigsJson = createEmptyWalletConfigsJson();
         }
     }
 
@@ -62,10 +67,10 @@ public class WalletConfigsManager {
         try {
             mWalletConfigsJson = new Gson().fromJson(walletConfigsJson, WalletConfigsJson.class);
         } catch (JsonSyntaxException e) {
-            createEmptyWalletConfigsJson();
+            mWalletConfigsJson = createEmptyWalletConfigsJson();
         }
         if (mWalletConfigsJson == null) {
-            createEmptyWalletConfigsJson();
+            mWalletConfigsJson = createEmptyWalletConfigsJson();
         }
     }
 
@@ -96,24 +101,23 @@ public class WalletConfigsManager {
         return mWalletConfigsJson;
     }
 
-    private void createEmptyWalletConfigsJson() {
-        mWalletConfigsJson = new Gson().fromJson("{\"connections\":[]}", WalletConfigsJson.class);
+    private WalletConfigsJson createEmptyWalletConfigsJson() {
+        return new Gson().fromJson("{\"connections\":[]}", WalletConfigsJson.class);
     }
 
     /**
-     * Checks if a wallet configuration with the given alias/name already exists.
+     * Checks if a wallet configuration with the given UUID exists.
      *
-     * @param alias The name of the wallet
+     * @param id The UUID of the wallet
      * @return
      */
-    public boolean doesWalletConfigExist(@NonNull String alias) {
-        return mWalletConfigsJson.doesWalletConfigExist(alias);
+    public boolean doesWalletConfigExist(@NonNull String id) {
+        return mWalletConfigsJson.doesWalletConfigExist(id);
     }
 
 
     /**
      * Adds a wallet configuration to our current setup.
-     * If a configuration exist with this alias, it will be overridden.
      * Do not forget to call apply() afterwards to make this change permanent.
      *
      * @param alias    Name of the wallet/configuration
@@ -123,8 +127,11 @@ public class WalletConfigsManager {
      * @param cert     The certificate. This is optional and can be null
      * @param macaroon The Macaroon. Encoded as base16 (hex)
      */
-    public void addWalletConfig(@NonNull String alias, String type, String host,
-                                int port, @Nullable String cert, String macaroon) {
+    public String addWalletConfig(@NonNull String alias, @NonNull String type, String host,
+                                  int port, @Nullable String cert, String macaroon) {
+
+        // Create the UUID for the new config
+        String id = UUID.randomUUID().toString();
 
         // Create the config
         WalletConfig config = new WalletConfig();
@@ -134,11 +141,45 @@ public class WalletConfigsManager {
         config.setPort(port);
         config.setCert(cert);
         config.setMacaroon(macaroon);
-
+        config.setId(id);
 
         // Add the config to our configurations array
-        mWalletConfigsJson.addWalletConfig(config);
+        mWalletConfigsJson.addWallet(config);
 
+        ZapLog.debug(LOG_TAG, "The wallet ID is:" + id);
+
+        return id;
+    }
+
+    /**
+     * Updates a wallet configuration in our current setup.
+     * Do not forget to call apply() afterwards to make this change permanent.
+     *
+     * @param id       UUID of the wallet/configuration that will be updated
+     * @param alias    Name of the wallet/configuration
+     * @param type     One of the following types: remote, local
+     * @param host     The host
+     * @param port     The port
+     * @param cert     The certificate. This is optional and can be null
+     * @param macaroon The Macaroon. Encoded as base16 (hex)
+     */
+    public String updateWalletConfig(@NonNull String id, @NonNull String alias, @NonNull String type, String host,
+                                     int port, @Nullable String cert, String macaroon) {
+
+        // Create the config
+        WalletConfig config = new WalletConfig();
+        config.setAlias(alias);
+        config.setType(type);
+        config.setHost(host);
+        config.setPort(port);
+        config.setCert(cert);
+        config.setMacaroon(macaroon);
+        config.setId(id);
+
+        // Add the config to our configurations array
+        mWalletConfigsJson.addWallet(config);
+
+        return id;
     }
 
 
@@ -150,7 +191,7 @@ public class WalletConfigsManager {
     public WalletConfig getCurrentWalletConfig() {
         WalletConfig config = getWalletConfig(PrefsUtil.getCurrentWalletConfig());
         if (config == null && mWalletConfigsJson.mConnections.size() > 0) {
-            PrefsUtil.edit().putString(PrefsUtil.CURRENT_WALLET_CONFIG, mWalletConfigsJson.mConnections.get(0).getAlias()).commit();
+            PrefsUtil.edit().putString(PrefsUtil.CURRENT_WALLET_CONFIG, mWalletConfigsJson.mConnections.get(0).getId()).commit();
             return mWalletConfigsJson.mConnections.get(0);
         }
 
@@ -159,34 +200,90 @@ public class WalletConfigsManager {
 
 
     /**
-     * Load a wallet configuration by its alias/name.
+     * Load a wallet configuration by its UUID.
      *
-     * @param alias The name of the wallet
-     * @return Returns null if no configuration is found for the given alias
+     * @param id The UUID of the wallet
+     * @return Returns null if no configuration is found for the given uuid
      */
-    public WalletConfig getWalletConfig(@NonNull String alias) {
-        return mWalletConfigsJson.getConnection(alias);
+    public WalletConfig getWalletConfig(@NonNull String id) {
+        return mWalletConfigsJson.getConnection(id);
+    }
+
+    /**
+     * Returns a List of all wallet configs sorted alphabetically.
+     *
+     * @param activeOnTop if true the currently active wallet is on top, ignoring alphabetical order.
+     * @return
+     */
+    public List<WalletConfig> getAllWalletConfigs(boolean activeOnTop) {
+        List<WalletConfig> sortedList = new ArrayList<>();
+        sortedList.addAll(mWalletConfigsJson.getConnections());
+
+        if (sortedList.size() > 1) {
+            // Sort the list alphabetically
+            Collections.sort(sortedList);
+
+            // Move the current config to top
+            if (activeOnTop) {
+                int index = -1;
+                for (WalletConfig tempConfig : sortedList) {
+                    if (tempConfig.getId().equals(PrefsUtil.getCurrentWalletConfig())) {
+                        index = sortedList.indexOf(tempConfig);
+                        break;
+                    }
+                }
+
+                WalletConfig currentConfig = sortedList.get(index);
+                sortedList.remove(index);
+                sortedList.add(0, currentConfig);
+            }
+        }
+
+        return sortedList;
     }
 
 
     /**
      * Renames the desired wallet config.
      *
-     * @param oldAlias
-     * @param newAlias
+     * @param id       The UUID of the wallet that should be renamed.
+     * @param newAlias The new alias
      * @return false if the old alias did not exist.
      */
-    public boolean renameWalletConfig(String oldAlias, @NonNull String newAlias) {
-        return mWalletConfigsJson.renameConnection(oldAlias, newAlias);
+    public boolean renameWalletConfig(String id, @NonNull String newAlias) {
+        return mWalletConfigsJson.renameWalletConfig(id, newAlias);
     }
 
     /**
      * Removes the desired wallet config.
      *
-     * @param alias
+     * @param id
      */
-    public boolean removeWalletConfig(@NonNull String alias) {
-        return mWalletConfigsJson.removeConnection(alias);
+    public boolean removeWalletConfig(@NonNull String id) {
+        return mWalletConfigsJson.removeWalletConfig(id);
+    }
+
+    public boolean hasAtLeastOneConfig() {
+        return mWalletConfigsJson.getConnections().size() != 0;
+    }
+
+    public boolean hasLocalConfig() {
+        if (!hasAtLeastOneConfig()) {
+            return false;
+        } else {
+            boolean hasLocal = false;
+            for (int i = 0; i < mWalletConfigsJson.getConnections().size(); i++) {
+                if (mWalletConfigsJson.getConnections().get(i).isLocal()) {
+                    hasLocal = true;
+                    break;
+                }
+            }
+            return hasLocal;
+        }
+    }
+
+    public void removeAllWalletConfigs(){
+        mWalletConfigsJson = createEmptyWalletConfigsJson();
     }
 
     /**

--- a/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
@@ -195,8 +195,7 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
             if (config instanceof LndConnectConfig) {
                 LndConnectConfig lndConfig = (LndConnectConfig) config;
 
-                String id;
-                id = walletConfigsManager.addWalletConfig(config.getHost(),
+                String id = walletConfigsManager.addWalletConfig(config.getHost(),
                         WalletConfig.WALLET_TYPE_REMOTE, lndConfig.getHost(), lndConfig.getPort(),
                         lndConfig.getCert(), lndConfig.getMacaroon());
 
@@ -209,8 +208,7 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
             } else if (config instanceof BTCPayConfig) {
                 BTCPayConfig btcPayConfig = (BTCPayConfig) config;
 
-                String id;
-                id = walletConfigsManager.addWalletConfig(config.getHost(),
+                String id = walletConfigsManager.addWalletConfig(config.getHost(),
                         WalletConfig.WALLET_TYPE_REMOTE, btcPayConfig.getHost(), btcPayConfig.getPort(),
                         null, btcPayConfig.getMacaroon());
 

--- a/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
@@ -18,15 +18,18 @@ import zapsolutions.zap.R;
 import zapsolutions.zap.baseClasses.BaseScannerActivity;
 import zapsolutions.zap.connection.HttpClient;
 import zapsolutions.zap.connection.RemoteConfiguration;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfig;
 import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.connection.parseConnectionData.btcPay.BTCPayConfig;
 import zapsolutions.zap.connection.parseConnectionData.btcPay.BTCPayConfigParser;
 import zapsolutions.zap.connection.parseConnectionData.lndConnect.LndConnectConfig;
 import zapsolutions.zap.connection.parseConnectionData.lndConnect.LndConnectStringParser;
 import zapsolutions.zap.util.ClipBoardUtil;
+import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.RefConstants;
 import zapsolutions.zap.util.TimeOutUtil;
 import zapsolutions.zap.util.UserGuardian;
+import zapsolutions.zap.util.Wallet;
 import zapsolutions.zap.util.ZapLog;
 
 public class ConnectRemoteNodeActivity extends BaseScannerActivity {
@@ -192,22 +195,28 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
             if (config instanceof LndConnectConfig) {
                 LndConnectConfig lndConfig = (LndConnectConfig) config;
 
-                walletConfigsManager.addWalletConfig(WalletConfigsManager.DEFAULT_WALLET_NAME,
-                        "remote", lndConfig.getHost(), lndConfig.getPort(),
+                String id;
+                id = walletConfigsManager.addWalletConfig(config.getHost(),
+                        WalletConfig.WALLET_TYPE_REMOTE, lndConfig.getHost(), lndConfig.getPort(),
                         lndConfig.getCert(), lndConfig.getMacaroon());
 
                 walletConfigsManager.apply();
+
+                PrefsUtil.edit().putString(PrefsUtil.CURRENT_WALLET_CONFIG, id).commit();
 
                 success = true;
 
             } else if (config instanceof BTCPayConfig) {
                 BTCPayConfig btcPayConfig = (BTCPayConfig) config;
 
-                walletConfigsManager.addWalletConfig(WalletConfigsManager.DEFAULT_WALLET_NAME,
-                        "remote", btcPayConfig.getHost(), btcPayConfig.getPort(),
+                String id;
+                id = walletConfigsManager.addWalletConfig(config.getHost(),
+                        WalletConfig.WALLET_TYPE_REMOTE, btcPayConfig.getHost(), btcPayConfig.getPort(),
                         null, btcPayConfig.getMacaroon());
 
                 walletConfigsManager.apply();
+
+                PrefsUtil.edit().putString(PrefsUtil.CURRENT_WALLET_CONFIG, id).commit();
 
                 success = true;
 
@@ -224,8 +233,11 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
             // We use commit here, as we want to be sure, that the data is saved and readable when we want to access it in the next step.
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
             prefs.edit()
-                    .putBoolean("isWalletSetup", true)
+                    .putBoolean(PrefsUtil.IS_WALLET_SETUP, true)
                     .commit();
+
+            // In case another wallet was open before, we want to have all values reset.
+            Wallet.getInstance().reset();
 
             // Show home screen, remove history stack
             Intent intent = new Intent(ConnectRemoteNodeActivity.this, HomeActivity.class);

--- a/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
@@ -197,7 +197,7 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
 
                 String id = walletConfigsManager.addWalletConfig(config.getHost(),
                         WalletConfig.WALLET_TYPE_REMOTE, lndConfig.getHost(), lndConfig.getPort(),
-                        lndConfig.getCert(), lndConfig.getMacaroon());
+                        lndConfig.getCert(), lndConfig.getMacaroon()).getId();
 
                 walletConfigsManager.apply();
 
@@ -210,7 +210,7 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
 
                 String id = walletConfigsManager.addWalletConfig(config.getHost(),
                         WalletConfig.WALLET_TYPE_REMOTE, btcPayConfig.getHost(), btcPayConfig.getPort(),
-                        null, btcPayConfig.getMacaroon());
+                        null, btcPayConfig.getMacaroon()).getId();
 
                 walletConfigsManager.apply();
 

--- a/app/src/main/java/zapsolutions/zap/util/PrefsUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PrefsUtil.java
@@ -78,7 +78,7 @@ public class PrefsUtil {
     }
 
     public static String getCurrentWalletConfig() {
-        return getPrefs().getString(CURRENT_WALLET_CONFIG, WalletConfigsManager.DEFAULT_WALLET_NAME);
+        return getPrefs().getString(CURRENT_WALLET_CONFIG, "");
     }
 
     public static boolean isPinEnabled() {

--- a/app/src/main/java/zapsolutions/zap/util/RefConstants.java
+++ b/app/src/main/java/zapsolutions/zap/util/RefConstants.java
@@ -7,8 +7,14 @@ public class RefConstants {
     /* This value has to be increased if any changes are made, that break the current implementation.
     It should ONLY be UPDATED ON BREAKING CHANGES.
     For example the hashing algorithm of the PIN. It will basically cause the app to reset itself on
-    next startup. HANDLE THIS WITH CARE. IT MIGHT CAUSE LOSS OF IMPORTANT DATA FOR USERS. */
-    public static final int CURRENT_SETTINGS_VERSION = 17;
+    next startup. HANDLE THIS WITH CARE. IT MIGHT CAUSE LOSS OF IMPORTANT DATA FOR USERS.
+
+    History:
+    16: Biometrics and new Cryptography using Android Keystore
+    17: Removed deviceID usage
+    18: Wallet name based WalletConfigs -> UUID based WalletConfigs
+    */
+    public static final int CURRENT_SETTINGS_VERSION = 18;
 
     // If any changes are done here, CURRENT_SETTINGS_VERSION has to be updated.
     public static final int NUM_HASH_ITERATIONS = 5000;

--- a/app/src/test/java/zapsolutions/zap/ConnectionManagerTest.java
+++ b/app/src/test/java/zapsolutions/zap/ConnectionManagerTest.java
@@ -23,20 +23,23 @@ import static junit.framework.TestCase.assertTrue;
 
 public class ConnectionManagerTest {
 
+    private static String WALLET_1_ID = "e4f2fcf7-82c7-46f4-8867-50c3f8a603f4";
+    private static String WALLET_2_ID = "a4f2fcf7-82c7-46f4-8867-50c3f8a603f4";
+
     @Test
     public void givenNoConfigs_whenDoesWalletExist_thenReturnFalse() {
         WalletConfigsManager manager = new WalletConfigsManager(null);
-        boolean result = manager.doesWalletConfigExist("test");
+        boolean result = manager.doesWalletConfigExist(WALLET_1_ID);
 
         assertFalse(result);
     }
 
 
     @Test
-    public void givenExistingAlias_whenDoesWalletExist_thenReturnTrue() {
+    public void givenExistingId_whenDoesWalletExist_thenReturnTrue() {
         String configJson = readStringFromFile("wallet_configs.json");
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        boolean result = manager.doesWalletConfigExist("firstwalletname");
+        boolean result = manager.doesWalletConfigExist(WALLET_1_ID);
 
         assertTrue(result);
     }
@@ -44,26 +47,27 @@ public class ConnectionManagerTest {
     @Test
     public void givenNoConfigs_whenLoadWalletConfig_thenReturnNull() {
         WalletConfigsManager manager = new WalletConfigsManager(null);
-        WalletConfig result = manager.getWalletConfig("firstwalletname");
+        WalletConfig result = manager.getWalletConfig(WALLET_1_ID);
 
         assertNull(result);
     }
 
     @Test
-    public void givenNonExistingAlias_whenLoadWalletConfig_thenReturnNull() {
+    public void givenNonExistingId_whenLoadWalletConfig_thenReturnNull() {
         String configJson = readStringFromFile("wallet_configs.json");
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        WalletConfig result = manager.getWalletConfig("test");
+        WalletConfig result = manager.getWalletConfig("000");
 
         assertNull(result);
     }
 
     @Test
-    public void givenExistingAlias_whenLoadWalletConfig_thenReceiveCorrectWalletConfig() {
+    public void givenExistingId_whenLoadWalletConfig_thenReceiveCorrectWalletConfig() {
         String configJson = readStringFromFile("wallet_configs.json");
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        WalletConfig result = manager.getWalletConfig("firstwalletname");
+        WalletConfig result = manager.getWalletConfig(WALLET_1_ID);
 
+        assertEquals(WALLET_1_ID, result.getId());
         assertEquals("FirstWalletName", result.getAlias());
         assertEquals("remote", result.getType());
         assertEquals("TestHost", result.getHost());
@@ -73,12 +77,12 @@ public class ConnectionManagerTest {
     }
 
     @Test
-    public void givenNewAlias_whenAddWalletConfig_thenReceiveUpdatedWalletConfigs() throws UnsupportedEncodingException {
-        WalletConfig expected = readFromFile("wallet_configs.json").getConnection("FirstWalletName");
+    public void givenNewId_whenAddWalletConfig_thenReceiveUpdatedWalletConfigs() throws UnsupportedEncodingException {
+        WalletConfig expected = readFromFile("wallet_configs.json").getConnection(WALLET_1_ID);
 
         WalletConfigsManager manager = new WalletConfigsManager(null);
         manager.addWalletConfig("FirstWalletName", "remote", "TestHost", 10009, "TestCert", "TestMacaroon");
-        WalletConfig actual = manager.getWalletConfig("FirstWalletName");
+        WalletConfig actual = manager.getWalletConfigsJson().getConnections().get(0);
 
         assertEquals(expected.getAlias(), actual.getAlias());
         assertEquals(expected.getCert(), actual.getCert());
@@ -89,24 +93,12 @@ public class ConnectionManagerTest {
     }
 
     @Test
-    public void givenExistingAlias_whenAddWalletConfig_thenReceiveUpdatedWalletConfigs() throws UnsupportedEncodingException {
-        WalletConfig expected = readFromFile("wallet_configs_modify.json").getConnection("FirstWalletName");
-
-        String configJson = readStringFromFile("wallet_configs_create.json");
-        WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        manager.addWalletConfig("FirstWalletName", "remote", "ModifiedHost", 10009, "TestCert", "TestMacaroon");
-        WalletConfig actual = manager.getWalletConfig("FirstWalletName");
-
-        assertEquals(expected.getHost(), actual.getHost());
-    }
-
-    @Test
-    public void givenNonExistingAlias_whenRemoveWalletConfig_thenReturnFalse() {
+    public void givenNonExistingId_whenRemoveWalletConfig_thenReturnFalse() {
         String configJson = readStringFromFile("wallet_configs.json");
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
 
         String expected = new Gson().toJson(manager.getWalletConfigsJson());
-        boolean removed = manager.removeWalletConfig("test");
+        boolean removed = manager.removeWalletConfig("000");
         String result = new Gson().toJson(manager.getWalletConfigsJson());
 
         assertFalse(removed);
@@ -114,51 +106,41 @@ public class ConnectionManagerTest {
     }
 
     @Test
-    public void givenExistingAlias_whenRemoveWalletConfig_thenReceiveUpdatedWalletConfigs() {
+    public void givenExistingId_whenRemoveWalletConfig_thenReceiveUpdatedWalletConfigs() {
         String configJson = readStringFromFile("wallet_configs.json");
 
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        boolean removed = manager.removeWalletConfig("secondwalletname");
+        boolean removed = manager.removeWalletConfig(WALLET_2_ID);
 
         assertTrue(removed);
-        assertNull(manager.getWalletConfig("SecondWalletName"));
-        assertNotNull(manager.getWalletConfig("FirstWalletName"));
+        assertNull(manager.getWalletConfig(WALLET_2_ID));
+        assertNotNull(manager.getWalletConfig(WALLET_1_ID));
     }
 
     @Test
-    public void givenNonExistingAlias_whenRenameWalletConfig_thenReturnFalse() {
+    public void givenNonExistingId_whenRenameWalletConfig_thenReturnFalse() {
         String configJson = readStringFromFile("wallet_configs.json");
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
         String expected = new Gson().toJson(manager.getWalletConfigsJson());
-        boolean renamed = manager.renameWalletConfig("test", "test2");
+        boolean renamed = manager.renameWalletConfig("000", "test2");
         String result = new Gson().toJson(manager.getWalletConfigsJson());
 
         assertFalse(renamed);
         assertEquals(expected, result);
     }
 
-    @Test
-    public void givenExistingAlias_whenRenameToExitingWalletConfig_thenReturnFalse() {
-        String configJson = readStringFromFile("wallet_configs.json");
-        WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        String expected = new Gson().toJson(manager.getWalletConfigsJson());
-        boolean renamed = manager.renameWalletConfig("FirstWalletName", "SecondWalletName");
-        String result = new Gson().toJson(manager.getWalletConfigsJson());
-
-        assertFalse(renamed);
-        assertEquals(expected, result);
-    }
 
     @Test
-    public void givenExistingAlias_whenRenameWalletConfig_thenReceiveUpdatedWalletConfigs() throws UnsupportedEncodingException {
-        WalletConfig expected = readFromFile("wallet_configs_rename.json").getConnection("NewWalletName");
+    public void givenExistingId_whenRenameWalletConfig_thenReceiveUpdatedWalletConfigs() throws UnsupportedEncodingException {
+        WalletConfig expected = readFromFile("wallet_configs_rename.json").getConnection(WALLET_1_ID);
         String configJson = readStringFromFile("wallet_configs_create.json");
         WalletConfigsManager manager = new WalletConfigsManager(configJson);
-        boolean renamed = manager.renameWalletConfig("FirstWalletName", "NewWalletName");
-        WalletConfig actual = manager.getWalletConfig("newWalletName");
+        boolean renamed = manager.renameWalletConfig(WALLET_1_ID, "NewWalletName");
+        WalletConfig actual = manager.getWalletConfig(WALLET_1_ID);
 
         assertTrue(renamed);
-        assertNotNull(manager.getWalletConfig("NewWalletName"));
+        assertNotNull(manager.getWalletConfig(WALLET_1_ID));
+        assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getAlias(), actual.getAlias());
         assertEquals(expected.getCert(), actual.getCert());
         assertEquals(expected.getType(), actual.getType());

--- a/app/src/test/resources/wallet_configs.json
+++ b/app/src/test/resources/wallet_configs.json
@@ -1,6 +1,7 @@
 {
   "connections": [
     {
+      "id": "e4f2fcf7-82c7-46f4-8867-50c3f8a603f4",
       "alias": "FirstWalletName",
       "type": "remote",
       "host": "TestHost",
@@ -9,6 +10,7 @@
       "macaroon": "TestMacaroon"
     },
     {
+      "id": "a4f2fcf7-82c7-46f4-8867-50c3f8a603f4",
       "alias": "SecondWalletName",
       "type": "local",
       "host": "host",

--- a/app/src/test/resources/wallet_configs_create.json
+++ b/app/src/test/resources/wallet_configs_create.json
@@ -1,6 +1,7 @@
 {
   "connections": [
     {
+      "id": "e4f2fcf7-82c7-46f4-8867-50c3f8a603f4",
       "alias": "FirstWalletName",
       "type": "remote",
       "cert": "TestCert",

--- a/app/src/test/resources/wallet_configs_modify.json
+++ b/app/src/test/resources/wallet_configs_modify.json
@@ -1,6 +1,7 @@
 {
   "connections": [
     {
+      "id": "e4f2fcf7-82c7-46f4-8867-50c3f8a603f4",
       "alias": "FirstWalletName",
       "type": "remote",
       "cert": "TestCert",

--- a/app/src/test/resources/wallet_configs_rename.json
+++ b/app/src/test/resources/wallet_configs_rename.json
@@ -1,6 +1,7 @@
 {
   "connections": [
     {
+      "id": "e4f2fcf7-82c7-46f4-8867-50c3f8a603f4",
       "alias": "NewWalletName",
       "type": "remote",
       "cert": "TestCert",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is a preparation for multiwallet support.
Wallet data is no longer identified by a name, but by a UUID.
In addition the wallet data is now comparable by name, which enables us to sort lists of wallets by name later.
The required conversion of wallet data for users that already are connected to a wallet is also included in this PR. This means existing users will not even notice the change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Paving the way for multiwallet support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9, both a fresh install and as update from the previous version

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.