### PR TITLE
Call balance updated listener only when all balances are fetched

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -295,6 +295,7 @@ public class Wallet {
             return true;
         }).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(aBoolean -> {
             // Zip executed without error
+            broadcastBalanceUpdate();
         }, throwable -> ZapLog.debug(LOG_TAG, "Exception in fetch balance task: " + throwable.getMessage())));
     }
 
@@ -1071,18 +1072,15 @@ public class Wallet {
         mOnChainBalanceTotal = total;
         mOnChainBalanceConfirmed = confirmed;
         mOnChainBalanceUnconfirmed = unconfirmed;
-        broadcastBalanceUpdate();
     }
 
     private void setChannelBalance(long balance, long pendingOpen) {
         mChannelBalance = balance;
         mChannelBalancePendingOpen = pendingOpen;
-        broadcastBalanceUpdate();
     }
 
     private void setChannelBalanceLimbo(long balanceLimbo) {
         mChannelBalanceLimbo = balanceLimbo;
-        broadcastBalanceUpdate();
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Call balance updated listener only when all balances are fetched instead of every time when one part of the balance request finished.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is made for 2 reasons.
1. It looks awkward if the balance changes 3 times in a row very fast. I think it is better to wait a tenth of a second longer and get the final result.
2. Calling the balance updated listener multiple times causes code to be executed mutiple times cluttering the debug log and making debugging harder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.