### PR TITLE
Fix NullPointer when reading error message

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -405,7 +405,7 @@ public class SendBSDFragment extends RxBSDFragment {
                                     ZapLog.debug(LOG_TAG, throwable.getMessage());
 
                                     String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ":";
-                                    String errormessage = throwable.getCause().getMessage().replace("UNKNOWN:", errorPrefix);
+                                    String errormessage = throwable.getMessage().replace("UNKNOWN:", errorPrefix);
                                     mHandler.postDelayed(() -> switchToFailedScreen(errormessage), 300);
                                 }));
                     } else {
@@ -649,7 +649,7 @@ public class SendBSDFragment extends RxBSDFragment {
                     ZapLog.debug(LOG_TAG, throwable.getMessage());
 
                     String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ":";
-                    String errormessage = throwable.getCause().getMessage().replace("UNKNOWN:", errorPrefix);
+                    String errormessage = throwable.getMessage().replace("UNKNOWN:", errorPrefix);
                     mHandler.postDelayed(() -> switchToFailedScreen(errormessage), 300);
 
                 }));


### PR DESCRIPTION
## Description
In case of an error during the payment, we want to show the error message from LND to the user.
It seems that the error thrown does not include a cause sometimes, therefor we get a `NullPointer` exception and won't show the real error.

## Motivation and Context
This change removes the part of getting the cause and directly reads the error message.

## How Has This Been Tested?
Pixel 3, API 29, LND 0.9.2-beta

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.