### PR TITLE
Fix overpaid invoice display in transaction history

### DIFF
--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnInvoiceViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnInvoiceViewHolder.java
@@ -54,11 +54,11 @@ public class LnInvoiceViewHolder extends TransactionViewHolder {
             }
         } else {
             // if a specific value was requested
-            if (amtPayed.equals(amt)) {
+            if (Wallet.getInstance().isInvoicePayed(lnInvoiceItem.getInvoice())) {
                 // The invoice has been payed
                 setIcon(TransactionIcon.LIGHTNING);
                 setPrimaryDescription(mContext.getString(R.string.received));
-                setAmount(amt, true);
+                setAmount(amtPayed, true);
             } else {
                 // The invoice has not been payed yet
                 setIcon(TransactionIcon.PENDING);

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/transactionDetails/InvoiceDetailBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/transactionDetails/InvoiceDetailBSDFragment.java
@@ -122,7 +122,7 @@ public class InvoiceDetailBSDFragment extends BottomSheetDialogFragment {
             }
         } else {
             // if a specific value was requested
-            if (amountPayed.equals(invoiceAmount)) {
+            if (Wallet.getInstance().isInvoicePayed(invoice)) {
                 // The invoice has been payed
                 bindPayedInvoice(invoice);
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the way overpaid invoices are displayed in the transaction history.
Before this PR they were displayed as expired invoice.
Now they are displayed as received lightning payment and the actual payed amount is displayed instead of the requested one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We tried to fix this once, but didn't test it as we didn't have such a payment in our history.
Today it happened to myself, so it was easy to test and I saw that we only partially fixed it last time.
Issue #165 is now really fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.