### PR TITLE
Improve handling for URI and NFC

### DIFF
--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -491,7 +491,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
 
             @Override
             public void onValidLnurlPay() {
-                showError(getResources().getString(R.string.string_analyzer_unrecognized_data), RefConstants.ERROR_DURATION_SHORT);
+                showError(getResources().getString(R.string.lnurl_unsupported_type), RefConstants.ERROR_DURATION_SHORT);
             }
 
             @Override

--- a/app/src/main/java/zapsolutions/zap/customView/WalletSpinner.java
+++ b/app/src/main/java/zapsolutions/zap/customView/WalletSpinner.java
@@ -94,6 +94,12 @@ public class WalletSpinner extends AppCompatSpinner {
         });
     }
 
+    @Override
+    public boolean performClick() {
+        updateList();
+        return super.performClick();
+    }
+
     public void updateList() {
 
         initFinished = false;

--- a/app/src/main/java/zapsolutions/zap/lnurl/LnUrlWithdrawBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/lnurl/LnUrlWithdrawBSDFragment.java
@@ -3,6 +3,7 @@ package zapsolutions.zap.lnurl;
 
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.os.Bundle;
 import android.os.Handler;
@@ -89,6 +90,16 @@ public class LnUrlWithdrawBSDFragment extends RxBSDFragment {
 
     private Handler mHandler;
     private LnUrlWithdrawResponse mWithdrawData;
+
+    public static LnUrlWithdrawBSDFragment createWithdrawDialog(LnUrlWithdrawResponse response) {
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(LnUrlWithdrawResponse.ARGS_KEY, response);
+        Intent intent = new Intent();
+        intent.putExtras(bundle);
+        LnUrlWithdrawBSDFragment lnUrlWithdrawBSDFragment = new LnUrlWithdrawBSDFragment();
+        lnUrlWithdrawBSDFragment.setArguments(intent.getExtras());
+        return lnUrlWithdrawBSDFragment;
+    }
 
 
     @Nullable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,6 +366,7 @@
     <string name="confirm_wallet_deletion">Do you really want to delete this wallet?</string>
     <string name="no_wallets">No wallets</string>
     <string name="spinner_manage_wallets">Manage…</string>
+    <string name="wallet_added">Wallet has been added.</string>
 
     <string name="lnurl_withdraw_success">Withdraw\nsuccessful</string>
     <string name="lnurl_withdraw_fail">Withdraw\nfailed</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the way URI or NFC messages are handled.
Previously only Bitcoin or Lightning invoices could be handeled.
Now LNURL withdraw request can be handled as well.
In theory wallet connections and open channel request can be handled as well, but as they do not have an URI scheme they can actually never be called. (NFC plain Text is not supported right now)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enable the user to click on a Withdraw link and open Zap as an associated app.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

My S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.