### PR TITLE
Utilize WalletConfigsManager to check for existing wallets

### DIFF
--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -39,6 +39,7 @@ import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.connection.RemoteConfiguration;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.connection.internetConnectionStatus.NetworkChangeReceiver;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.fragments.OpenChannelBSDFragment;
 import zapsolutions.zap.fragments.SendBSDFragment;
 import zapsolutions.zap.fragments.SettingsFragment;
@@ -237,7 +238,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
 
     public void openWallet() {
         // Start lnd connection
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             TimeOutUtil.getInstance().setCanBeRestarted(true);
 
             LndConnection.getInstance().openConnection();
@@ -308,7 +309,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
         Wallet.getInstance().cancelSubscriptions();
 
         // Kill lnd connection
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             LndConnection.getInstance().closeConnection();
         }
     }
@@ -334,7 +335,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
 
     @Override
     public void onInfoUpdated(boolean connected) {
-        if ((PrefsUtil.isWalletSetup())) {
+        if ((WalletConfigsManager.getInstance().hasAnyConfigs())) {
             if (!Wallet.getInstance().isTestnet() && Wallet.getInstance().isConnectedToLND()) {
                 if (!mMainnetWarningShownOnce) {
                     // Show mainnet not ready warning
@@ -459,7 +460,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
         NfcUtil.readTag(this, intent, new NfcUtil.OnNfcResponseListener() {
             @Override
             public void onSuccess(String payload) {
-                if (PrefsUtil.isWalletSetup()) {
+                if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                     analyzeString(payload);
                 } else {
                     ZapLog.debug(LOG_TAG, "Wallet not setup.");

--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -25,7 +25,7 @@ public class LandingActivity extends BaseAppCompatActivity {
         super.onCreate(savedInstanceState);
 
         // Save data when App was started with a task.
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
 
             // Zap was started from an URI link.
             Intent intent = getIntent();
@@ -62,7 +62,7 @@ public class LandingActivity extends BaseAppCompatActivity {
     }
 
     private void resetApp() {
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             // Reset settings
             PrefsUtil.edit().clear().commit();
 
@@ -79,7 +79,7 @@ public class LandingActivity extends BaseAppCompatActivity {
     }
 
     private void convertWalletNameToUUID() {
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                 WalletConfig config = (WalletConfig) WalletConfigsManager.getInstance().getWalletConfigsJson().getConnections().toArray()[0];
                 WalletConfigsManager.getInstance().removeAllWalletConfigs();
@@ -100,7 +100,7 @@ public class LandingActivity extends BaseAppCompatActivity {
         // Set new settings version
         PrefsUtil.edit().putInt(PrefsUtil.SETTINGS_VERSION, RefConstants.CURRENT_SETTINGS_VERSION).commit();
 
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             PinScreenUtil.askForAccess(this, () -> {
                 Intent homeIntent = new Intent(this, HomeActivity.class);
                 homeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/zapsolutions/zap/connection/internetConnectionStatus/NetworkChangeReceiver.java
+++ b/app/src/main/java/zapsolutions/zap/connection/internetConnectionStatus/NetworkChangeReceiver.java
@@ -7,6 +7,7 @@ import android.os.Handler;
 
 import java.util.concurrent.RejectedExecutionException;
 
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.Wallet;
 import zapsolutions.zap.util.ZapLog;
@@ -21,7 +22,7 @@ public class NetworkChangeReceiver extends BroadcastReceiver {
 
         int status = NetworkUtil.getConnectivityStatusString(context);
 
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             if (status == NetworkUtil.NETWORK_STATUS_NOT_CONNECTED) {
                 // The following command will find out, if we have a connection to LND
                 Wallet.getInstance().fetchInfoFromLND();

--- a/app/src/main/java/zapsolutions/zap/fragments/OpenChannelBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/OpenChannelBSDFragment.java
@@ -37,6 +37,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.snackbar.Snackbar;
 
 import zapsolutions.zap.R;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.customView.NumpadView;
 import zapsolutions.zap.lightning.LightningNodeUri;
 import zapsolutions.zap.util.MonetaryUtil;
@@ -198,7 +199,7 @@ public class OpenChannelBSDFragment extends BottomSheetDialogFragment implements
                 long minSendAmount = 20000;
                 long maxSendAmount = 17666215;
 
-                if (PrefsUtil.isWalletSetup()) {
+                if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                     long onChainAvailable = Wallet.getInstance().getBalances().onChainConfirmed();
 
                     if (onChainAvailable < maxSendAmount) {

--- a/app/src/main/java/zapsolutions/zap/fragments/ReceiveBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/ReceiveBSDFragment.java
@@ -42,6 +42,7 @@ import zapsolutions.zap.HomeActivity;
 import zapsolutions.zap.R;
 import zapsolutions.zap.channelManagement.ManageChannelsActivity;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.customView.NumpadView;
 import zapsolutions.zap.lnurl.ScanLnUrlWithdrawActivity;
 import zapsolutions.zap.util.HelpDialogUtil;
@@ -174,7 +175,7 @@ public class ReceiveBSDFragment extends RxBSDFragment {
                 mIvBsdIcon.setImageDrawable(getActivity().getResources().getDrawable(R.drawable.ic_icon_modal_lightning));
                 mTvTitle.setText(R.string.receive_lightning_request);
 
-                boolean canReceiveLightningPayment = hasLightningIncomeBalance() || !PrefsUtil.isWalletSetup();
+                boolean canReceiveLightningPayment = hasLightningIncomeBalance() || !WalletConfigsManager.getInstance().hasAnyConfigs();
 
                 // Animate bsd Icon size
                 ObjectAnimator scaleUpX = ObjectAnimator.ofFloat(mIvBsdIcon, "scaleX", 0f, 1f);
@@ -379,7 +380,7 @@ public class ReceiveBSDFragment extends RxBSDFragment {
                 } else {
                     long maxReceivable;
                     mUseValueBeforeUnitSwitch = false;
-                    if (PrefsUtil.isWalletSetup()) {
+                    if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                         maxReceivable = Wallet.getInstance().getMaxLightningReceiveAmount();
                     } else {
                         maxReceivable = 500000000000L;
@@ -443,7 +444,7 @@ public class ReceiveBSDFragment extends RxBSDFragment {
     }
 
     private void generateRequest() {
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             // The wallet is setup. Communicate with LND and generate the request.
             if (mOnChain) {
 

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -49,6 +49,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import zapsolutions.zap.R;
 import zapsolutions.zap.channelManagement.ManageChannelsActivity;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.customView.LightningFeeView;
 import zapsolutions.zap.customView.NumpadView;
 import zapsolutions.zap.customView.OnChainFeeView;
@@ -225,13 +226,13 @@ public class SendBSDFragment extends RxBSDFragment {
                     long maxSendable;
                     if (mOnChain) {
 
-                        if (PrefsUtil.isWalletSetup()) {
+                        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                             maxSendable = Wallet.getInstance().getBalances().onChainConfirmed();
                         } else {
                             maxSendable = Wallet.getInstance().getDemoBalances().onChainConfirmed();
                         }
                     } else {
-                        if (PrefsUtil.isWalletSetup()) {
+                        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                             maxSendable = Wallet.getInstance().getMaxLightningSendAmount();
                         } else {
                             maxSendable = 750000;
@@ -427,7 +428,7 @@ public class SendBSDFragment extends RxBSDFragment {
                 public void onClick(View v) {
 
                     // send lightning payment
-                    if (PrefsUtil.isWalletSetup()) {
+                    if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                         SendRequest.Builder srb = SendRequest.newBuilder();
 
                         if (mLnPaymentRequest.getNumSatoshis() <= RefConstants.LN_PAYMENT_FEE_THRESHOLD) {

--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -34,6 +34,7 @@ import zapsolutions.zap.R;
 import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.channelManagement.ManageChannelsActivity;
 import zapsolutions.zap.connection.manageWalletConfigs.Cryptography;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.pin.PinSetupActivity;
 import zapsolutions.zap.util.AppUtil;
 import zapsolutions.zap.util.MonetaryUtil;
@@ -152,7 +153,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         mPinPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
-                if (PrefsUtil.isWalletSetup()) {
+                if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                     if (PrefsUtil.isPinEnabled()) {
                         Intent intent = new Intent(getActivity(), PinSetupActivity.class);
                         intent.putExtra(RefConstants.SETUP_MODE, PinSetupActivity.CHANGE_PIN);

--- a/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
@@ -29,6 +29,7 @@ import zapsolutions.zap.SendActivity;
 import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.connection.internetConnectionStatus.NetworkUtil;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.customView.WalletSpinner;
 import zapsolutions.zap.setup.SetupActivity;
 import zapsolutions.zap.util.Balances;
@@ -242,7 +243,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
 
         // Action when clicked on "setup wallet"
         Button btnSetup = view.findViewById(R.id.setupWallet);
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             btnSetup.setVisibility(View.INVISIBLE);
         }
         btnSetup.setOnClickListener(new View.OnClickListener() {
@@ -278,7 +279,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         if (App.getAppContext().connectionToLNDEstablished) {
             connectionToLNDEstablished();
         } else {
-            if (PrefsUtil.isWalletSetup()) {
+            if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                 if (!LndConnection.getInstance().isConnected()) {
                     LndConnection.getInstance().openConnection();
                 }
@@ -292,7 +293,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
 
     private void connectionToLNDEstablished() {
 
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
 
             // Show info about mode (offline, testnet or mainnet) if it is already known
             onInfoUpdated(Wallet.getInstance().isInfoFetched());
@@ -312,7 +313,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         }
 
         Balances balances;
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             balances = Wallet.getInstance().getBalances();
         } else {
             balances = Wallet.getInstance().getDemoBalances();
@@ -372,7 +373,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
             mLoadingWalletLayout.setVisibility(View.GONE);
             mWalletNotConnectedLayout.setVisibility(View.GONE);
 
-            if (PrefsUtil.isWalletSetup()) {
+            if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                 if (Wallet.getInstance().isTestnet()) {
                     mTvMode.setText("TESTNET");
                     mTvMode.setVisibility(View.VISIBLE);
@@ -429,14 +430,14 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
             mExchangeRateListenerRegistered = true;
         }
 
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             mWalletSpinner.updateList();
             mWalletSpinner.setVisibility(View.VISIBLE);
         } else {
             mWalletSpinner.setVisibility(View.GONE);
         }
 
-        if (!PrefsUtil.isWalletSetup()) {
+        if (!WalletConfigsManager.getInstance().hasAnyConfigs()) {
             // If the App is not setup yet,
             // this will cause to get the status text updated. Otherwise it would be empty.
             Wallet.getInstance().simulateFetchInfoForDemo(NetworkUtil.isConnectedToInternet(getActivity()));
@@ -459,7 +460,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         if (success) {
             connectionToLNDEstablished();
         } else {
-            if (PrefsUtil.isWalletSetup()) {
+            if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                 if (error != Wallet.WalletLoadedListener.ERROR_LOCKED) {
                     onInfoUpdated(false);
                     if (error == Wallet.WalletLoadedListener.ERROR_AUTHENTICATION) {

--- a/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
@@ -128,12 +128,6 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
                 // Do not ask for pin again...
                 TimeOutUtil.getInstance().restartTimer();
 
-                // We use commit here, as we want to be sure, that the data is saved and readable when we want to access it in the next step.
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ConnectRemoteNodeActivity.this);
-                prefs.edit()
-                        .putBoolean(PrefsUtil.IS_WALLET_SETUP, true)
-                        .commit();
-
                 // In case another wallet was open before, we want to have all values reset.
                 Wallet.getInstance().reset();
 

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/TransactionHistoryFragment.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/TransactionHistoryFragment.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import zapsolutions.zap.R;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.transactionHistory.listItems.DateItem;
 import zapsolutions.zap.transactionHistory.listItems.HistoryListItem;
 import zapsolutions.zap.transactionHistory.listItems.LnInvoiceItem;
@@ -183,7 +184,7 @@ public class TransactionHistoryFragment extends Fragment implements Wallet.Histo
         List<HistoryListItem> expiredRequest = new LinkedList<>();
         List<HistoryListItem> internalTransactions = new LinkedList<>();
 
-        if (PrefsUtil.isWalletSetup()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
 
             // Add all payment relevant items to one of the lists above
 
@@ -305,7 +306,7 @@ public class TransactionHistoryFragment extends Fragment implements Wallet.Histo
 
     @Override
     public void onRefresh() {
-        if (PrefsUtil.isWalletSetup() && Wallet.getInstance().isInfoFetched()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs() && Wallet.getInstance().isInfoFetched()) {
             Wallet.getInstance().fetchLNDTransactionHistory();
         } else {
             mSwipeRefreshLayout.setRefreshing(false);

--- a/app/src/main/java/zapsolutions/zap/util/PinScreenUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PinScreenUtil.java
@@ -7,12 +7,13 @@ import android.content.Intent;
 
 import zapsolutions.zap.R;
 import zapsolutions.zap.connection.manageWalletConfigs.Cryptography;
+import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.pin.PinEntryActivity;
 
 public class PinScreenUtil {
 
     static public void askForAccess(Activity activity, OnSecurityCheckPerformedListener onSecurityCheckPerformedListener) {
-        if (PrefsUtil.isWalletSetup() && TimeOutUtil.getInstance().isTimedOut()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs() && TimeOutUtil.getInstance().isTimedOut()) {
             if (PrefsUtil.isPinEnabled()) {
                 // Go to PIN entry screen
                 Intent pinIntent = new Intent(activity, PinEntryActivity.class);

--- a/app/src/main/java/zapsolutions/zap/util/PrefsUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PrefsUtil.java
@@ -14,7 +14,6 @@ import zapsolutions.zap.customView.OnChainFeeView;
 public class PrefsUtil {
 
     // shared preference references
-    public static final String IS_WALLET_SETUP = "isWalletSetup";
     public static final String PREVENT_SCREEN_RECORDING = "preventScreenRecording";
     public static final String FIRST_CURRENCY_IS_PRIMARY = "firstCurrencyIsPrimary";
     public static final String PIN_HASH = "pin_hash";
@@ -52,10 +51,6 @@ public class PrefsUtil {
 
 
     // Shortcuts to often used preferences
-
-    public static boolean isWalletSetup() {
-        return getPrefs().getBoolean(IS_WALLET_SETUP, false);
-    }
 
     public static boolean preventScreenRecording() {
         return getPrefs().getBoolean(PREVENT_SCREEN_RECORDING, true);

--- a/app/src/main/java/zapsolutions/zap/walletManagement/WalletDetailsActivity.java
+++ b/app/src/main/java/zapsolutions/zap/walletManagement/WalletDetailsActivity.java
@@ -216,9 +216,6 @@ public class WalletDetailsActivity extends BaseAppCompatActivity {
             Wallet.getInstance().reset();
             LndConnection.getInstance().closeConnection();
             PrefsUtil.edit().remove(PrefsUtil.CURRENT_WALLET_CONFIG).commit();
-            if (!walletConfigsManager.hasAnyConfigs()) {
-                PrefsUtil.edit().putBoolean(PrefsUtil.IS_WALLET_SETUP, false).commit();
-            }
             Intent intent = new Intent(WalletDetailsActivity.this, LandingActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(intent);


### PR DESCRIPTION
## Description
Instead of a dedicated `Preference`, we want to use the `WalletConfigsManager` from now on to check for existing wallets.

## Motivation and Context
Remove deprecated functionality.

## How Has This Been Tested?
Tested with 2 remote wallets on Pixel 3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Maintenance 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.