### PR TITLE
Handle lndconnect URIs, fixed updating connection data of wallets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
 
                 <data android:scheme="bitcoin" />
                 <data android:scheme="lightning" />
+                <data android:scheme="lndconnect" />
 
             </intent-filter>
             <intent-filter>
@@ -47,6 +48,7 @@
 
                 <data android:scheme="bitcoin" />
                 <data android:scheme="lightning" />
+                <data android:scheme="lndconnect" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsManager.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsManager.java
@@ -114,6 +114,23 @@ public class WalletConfigsManager {
         return mWalletConfigsJson.doesWalletConfigExist(walletConfig);
     }
 
+    /**
+     * Checks if a wallet configuration already exists that points to the same destination.
+     *
+     * @param host
+     * @param port
+     * @return
+     */
+    public boolean doesDestinationExist(@NonNull String host, @NonNull int port) {
+        List<WalletConfig> configList = getAllWalletConfigs(false);
+        for (WalletConfig tempConfig : configList) {
+            if (tempConfig.getHost().equals(host) && tempConfig.getPort() == port) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     /**
      * Adds a wallet configuration to our current setup.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,6 +367,7 @@
     <string name="no_wallets">No wallets</string>
     <string name="spinner_manage_wallets">Manage…</string>
     <string name="wallet_added">Wallet has been added.</string>
+    <string name="wallet_already_exists">This wallet already exists.\nIf you want to update its connection data, please go to the walltes detail page.</string>
 
     <string name="lnurl_withdraw_success">Withdraw\nsuccessful</string>
     <string name="lnurl_withdraw_fail">Withdraw\nfailed</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds lndconnect as URI scheme that zap can handle.
Furthermore it prevents wallets from being added more than once and fixes a bug that appeared when trying to update the connection data of a wallet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Nayuta Core is a full node solution including lnd which runs on the smartphone.
They have a Zap connect button there which until now copys the lndconnect string.
With this update it should be possible to just hit the Zap button and the rest is done automatically.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

My S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.