### PR TITLE
Fix LNURL getting called twice bug

### DIFF
--- a/app/src/main/java/zapsolutions/zap/ScanActivity.java
+++ b/app/src/main/java/zapsolutions/zap/ScanActivity.java
@@ -84,6 +84,7 @@ public class ScanActivity extends BaseScannerActivity {
         try {
             LnurlDecoder.decode(data);
             readableDataFound(data);
+            return;
         } catch (LnurlDecoder.NoLnUrlDataException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes a bug that caused LNURLs to be called twice when scanning.
This is not allowed for LNURLs