### PR TITLE
Improved startup procedure

### DIFF
--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -22,8 +22,6 @@ public class LandingActivity extends BaseAppCompatActivity {
 
     private static final String LOG_TAG = LandingActivity.class.getName();
 
-    boolean doSetupFromUri = false;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -38,6 +36,7 @@ public class LandingActivity extends BaseAppCompatActivity {
             ZapLog.d(LOG_TAG, "URI was detected: " + uri.toString());
             if (!WalletConfigsManager.getInstance().hasAnyConfigs() && UriUtil.isLNDConnectUri(App.getAppContext().getUriSchemeData())) {
                 setupWalletFromUri();
+                return;
             }
         }
 
@@ -47,6 +46,7 @@ public class LandingActivity extends BaseAppCompatActivity {
             NfcUtil.readTag(LandingActivity.this, intent, payload -> App.getAppContext().setUriSchemeData(payload));
             if (!WalletConfigsManager.getInstance().hasAnyConfigs() && UriUtil.isLNDConnectUri(App.getAppContext().getUriSchemeData())) {
                 setupWalletFromUri();
+                return;
             }
         }
 
@@ -120,19 +120,15 @@ public class LandingActivity extends BaseAppCompatActivity {
             });
 
         } else {
+            // Clear connection data if something is there
+            PrefsUtil.edit().remove(PrefsUtil.WALLET_CONFIGS).commit();
 
-            if (!doSetupFromUri) {
-                // Clear connection data if something is there
-                PrefsUtil.edit().remove(PrefsUtil.WALLET_CONFIGS).commit();
-
-                Intent homeIntent = new Intent(this, HomeActivity.class);
-                startActivity(homeIntent);
-            }
+            Intent homeIntent = new Intent(this, HomeActivity.class);
+            startActivity(homeIntent);
         }
     }
 
     private void setupWalletFromUri() {
-        doSetupFromUri = true;
         Intent connectIntent = new Intent(this, ConnectRemoteNodeActivity.class);
         connectIntent.putExtra(ConnectRemoteNodeActivity.EXTRA_STARTED_FROM_URI, true);
         connectIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/zapsolutions/zap/connection/establishConnectionToLnd/LndConnection.java
+++ b/app/src/main/java/zapsolutions/zap/connection/establishConnectionToLnd/LndConnection.java
@@ -186,7 +186,7 @@ public class LndConnection {
      */
     private void shutdownChannel() {
         try {
-            if (mSecureChannel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS)) {
+            if (mSecureChannel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS)) {
                 ZapLog.d(LOG_TAG, "LND channel shutdown successfully...");
             } else {
                 ZapLog.e(LOG_TAG, "LND channel shutdown failed...");

--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -171,6 +171,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
+                getActivity().finishAffinity();
                 AppUtil.getInstance(getActivity()).restartApp();
                 return true;
             }

--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -113,6 +113,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
                                 // We have to use commit here, apply would not finish before the app is restarted.
                                 editor.commit();
+
+                                // FinishAffinity is needed here, otherwise the home activity still exist when restarting leading to lnd connection issues.
+                                getActivity().finishAffinity();
+
                                 AppUtil.getInstance(getActivity()).restartApp();
 
                             }

--- a/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
@@ -314,14 +314,6 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
 
         if (App.getAppContext().connectionToLNDEstablished) {
             walletLoadingCompleted();
-        } else {
-            if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
-                if (!LndConnection.getInstance().isConnected()) {
-                    LndConnection.getInstance().openConnection();
-                }
-
-                Wallet.getInstance().testLndConnectionAndLoadWallet();
-            }
         }
 
         return view;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the way the wallet is loaded.
Before "walletLoaded" was triggered as soon as the first getInfo command succeded.
Now "onLndConnectSuccess" is triggered instead at this stage.
"WalletLoaded" is now triggered after Balances and Channels have been fetched.

This PR also addresses some restart issues and wallet loading procedures in general.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the wallet was not already opened before and a lightning link (invoice or LNURL, etc.) was clicked, there was a problem.
The app started, the connection initialized and then the URI command was executed before the channels were fetched.
Therefore the app falsely reported "not enough funds" as it was 0 at that moment.
Now the URI command gets executed after Balances and Channels are fetched.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.