### PR TITLE
Display node uri instead of pubkey on identity screen

### DIFF
--- a/app/src/main/java/zapsolutions/zap/IdentityActivity.java
+++ b/app/src/main/java/zapsolutions/zap/IdentityActivity.java
@@ -13,17 +13,19 @@ import androidx.annotation.NonNull;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
+import zapsolutions.zap.customView.IdentitySwitchView;
 import zapsolutions.zap.customView.UserAvatarView;
 import zapsolutions.zap.util.ClipBoardUtil;
+import zapsolutions.zap.util.HelpDialogUtil;
 import zapsolutions.zap.util.UserGuardian;
 import zapsolutions.zap.util.Wallet;
 
 public class IdentityActivity extends BaseAppCompatActivity {
 
-    private String mDataToEncode;
     private Button mBtnHint;
     private UserAvatarView mUserAvatarView;
     private BottomNavigationView mBottomButtons;
+    private IdentitySwitchView mIdentitySwitchView;
     private TextView mTvPublicKey;
 
     @Override
@@ -32,14 +34,33 @@ public class IdentityActivity extends BaseAppCompatActivity {
         setContentView(R.layout.activity_identity);
 
         mUserAvatarView = findViewById(R.id.userAvatarView);
+        mIdentitySwitchView = findViewById(R.id.identityTypeSwitcher);
         mBottomButtons = findViewById(R.id.bottomButtons);
         mBtnHint = findViewById(R.id.hintButton);
         mTvPublicKey = findViewById(R.id.publicKey);
 
-        mUserAvatarView.setupWithNodePubKey(Wallet.getInstance().getIdentityPubKey(), true);
-        mDataToEncode = Wallet.getInstance().getIdentityPubKey();
-        //mTvPublicKey.setText(Wallet.getInstance().getIdentityPubKey());
+        mUserAvatarView.setupWithNodeUris(Wallet.getInstance().getNodeUris(), true);
 
+        if (mUserAvatarView.hasTorAndPublicIdentity()) {
+            mIdentitySwitchView.setVisibility(View.VISIBLE);
+            mIdentitySwitchView.setIdentityTypeChangedListener(new IdentitySwitchView.IdentityTypeChangedListener() {
+                @Override
+                public void onIdentityTypeChanged(IdentitySwitchView.IdentityType identityType) {
+                    switch (identityType) {
+                        case TOR:
+                            mUserAvatarView.showTorIdentity();
+                            break;
+                        case PUBLIC:
+                            mUserAvatarView.showClearNetIdentity();
+                            break;
+                        default:
+                            mUserAvatarView.showTorIdentity();
+                    }
+                }
+            });
+        } else {
+            mIdentitySwitchView.setVisibility(View.GONE);
+        }
 
         mUserAvatarView.setOnStateChangedListener(new UserAvatarView.OnStateChangedListener() {
             @Override
@@ -56,7 +77,6 @@ public class IdentityActivity extends BaseAppCompatActivity {
         });
 
 
-
         mBottomButtons.setOnNavigationItemSelectedListener(new BottomNavigationView.OnNavigationItemSelectedListener() {
             @Override
             public boolean onNavigationItemSelected(@NonNull MenuItem item) {
@@ -66,7 +86,7 @@ public class IdentityActivity extends BaseAppCompatActivity {
                     case R.id.action_share:
                         Intent shareIntent = new Intent();
                         shareIntent.setAction(Intent.ACTION_SEND);
-                        shareIntent.putExtra(Intent.EXTRA_TEXT, mDataToEncode);
+                        shareIntent.putExtra(Intent.EXTRA_TEXT, mUserAvatarView.getCurrentNodeIdentity().getAsString());
                         shareIntent.setType("text/plain");
                         String title = getResources().getString(R.string.shareDialogTitle);
                         startActivity(Intent.createChooser(shareIntent, title));
@@ -76,8 +96,8 @@ public class IdentityActivity extends BaseAppCompatActivity {
 
                         new UserGuardian(IdentityActivity.this, () -> {
                             // Copy data to clipboard
-                            ClipBoardUtil.copyToClipboard(getApplicationContext(), "NodePubKey", mDataToEncode);
-                        }).securityCopyToClipboard(mDataToEncode, UserGuardian.CLIPBOARD_DATA_TYPE_NODE_URI);
+                            ClipBoardUtil.copyToClipboard(getApplicationContext(), "NodePubKey", mUserAvatarView.getCurrentNodeIdentity().getAsString());
+                        }).securityCopyToClipboard(mUserAvatarView.getCurrentNodeIdentity().getAsString(), UserGuardian.CLIPBOARD_DATA_TYPE_NODE_URI);
                         break;
                 }
                 // Return false as we actually don't want to select it.
@@ -89,7 +109,7 @@ public class IdentityActivity extends BaseAppCompatActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
-        // getMenuInflater().inflate(R.menu.help_menu, menu);
+        getMenuInflater().inflate(R.menu.help_menu, menu);
         return true;
     }
 
@@ -97,13 +117,11 @@ public class IdentityActivity extends BaseAppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         // Handle action bar item clicks here.
         int id = item.getItemId();
-/*
+
         if (id == R.id.helpButton) {
-            HelpDialogUtil.showDialog(IdentityActivity.this, R.string.help_dialog_identity);
+            HelpDialogUtil.showDialog(IdentityActivity.this, R.string.identity_explanation);
             return true;
         }
-
- */
 
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/zapsolutions/zap/IdentityActivity.java
+++ b/app/src/main/java/zapsolutions/zap/IdentityActivity.java
@@ -96,7 +96,7 @@ public class IdentityActivity extends BaseAppCompatActivity {
 
                         new UserGuardian(IdentityActivity.this, () -> {
                             // Copy data to clipboard
-                            ClipBoardUtil.copyToClipboard(getApplicationContext(), "NodePubKey", mUserAvatarView.getCurrentNodeIdentity().getAsString());
+                            ClipBoardUtil.copyToClipboard(getApplicationContext(), "LightningUri", mUserAvatarView.getCurrentNodeIdentity().getAsString());
                         }).securityCopyToClipboard(mUserAvatarView.getCurrentNodeIdentity().getAsString(), UserGuardian.CLIPBOARD_DATA_TYPE_NODE_URI);
                         break;
                 }

--- a/app/src/main/java/zapsolutions/zap/IdentityActivity.java
+++ b/app/src/main/java/zapsolutions/zap/IdentityActivity.java
@@ -48,13 +48,13 @@ public class IdentityActivity extends BaseAppCompatActivity {
                 public void onIdentityTypeChanged(IdentitySwitchView.IdentityType identityType) {
                     switch (identityType) {
                         case TOR:
-                            mUserAvatarView.showTorIdentity();
+                            mUserAvatarView.showIdentity(true);
                             break;
                         case PUBLIC:
-                            mUserAvatarView.showClearNetIdentity();
+                            mUserAvatarView.showIdentity(false);
                             break;
                         default:
-                            mUserAvatarView.showTorIdentity();
+                            mUserAvatarView.showIdentity(true);
                     }
                 }
             });

--- a/app/src/main/java/zapsolutions/zap/customView/IdentitySwitchView.java
+++ b/app/src/main/java/zapsolutions/zap/customView/IdentitySwitchView.java
@@ -1,0 +1,116 @@
+package zapsolutions.zap.customView;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.constraintlayout.widget.ConstraintLayout;
+
+import com.google.android.material.tabs.TabLayout;
+
+import zapsolutions.zap.R;
+
+public class IdentitySwitchView extends ConstraintLayout {
+
+    private TabLayout mTabLayoutSendFeeSpeed;
+    private IdentityTypeChangedListener mIdentityTypeChangedListener;
+    private IdentityType mIdentityType;
+
+    public IdentitySwitchView(Context context) {
+        super(context);
+        init();
+    }
+
+    public IdentitySwitchView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public IdentitySwitchView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        View view = inflate(getContext(), R.layout.view_identity_switch, this);
+
+        mTabLayoutSendFeeSpeed = view.findViewById(R.id.identitySwitchTabLayout);
+
+        // Set tor as standard
+        setIdentityType(IdentityType.TOR);
+        mTabLayoutSendFeeSpeed.getTabAt(mIdentityType.ordinal()).select();
+
+
+        // Listen for identity type change by user
+        mTabLayoutSendFeeSpeed.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+            @Override
+            public void onTabSelected(TabLayout.Tab tab) {
+                if (tab.getText() != null) {
+                    if (tab.getText().equals(getResources().getString(IdentityType.TOR.getTitle()))) {
+                        setIdentityType(IdentityType.TOR);
+                    } else if (tab.getText().equals(getResources().getString(IdentityType.PUBLIC.getTitle()))) {
+                        setIdentityType(IdentityType.PUBLIC);
+                    }
+                }
+            }
+
+            @Override
+            public void onTabUnselected(TabLayout.Tab tab) {
+
+            }
+
+            @Override
+            public void onTabReselected(TabLayout.Tab tab) {
+
+            }
+        });
+    }
+
+    public IdentityType getIdentityType() {
+        return mIdentityType;
+    }
+
+    /**
+     * Set current identity type and notify listeners
+     */
+    private void setIdentityType(IdentityType identityType) {
+        mIdentityType = identityType;
+
+        // Notify listener about changed type
+        if (mIdentityTypeChangedListener != null) {
+            mIdentityTypeChangedListener.onIdentityTypeChanged(identityType);
+        }
+    }
+
+    public void setIdentityTypeChangedListener(IdentityTypeChangedListener identityTypeChangedListener) {
+        mIdentityTypeChangedListener = identityTypeChangedListener;
+    }
+
+    public enum IdentityType {
+        TOR,
+        PUBLIC;
+
+        public static IdentityType parseFromString(String enumAsString) {
+            try {
+                return valueOf(enumAsString);
+            } catch (Exception ex) {
+                return TOR;
+            }
+        }
+
+        public int getTitle() {
+            switch (this) {
+                case TOR:
+                    return R.string.identity_switch_tor;
+                case PUBLIC:
+                    return R.string.identity_switch_public;
+                default:
+                    return R.string.identity_switch_tor;
+            }
+        }
+    }
+
+    public interface IdentityTypeChangedListener {
+        void onIdentityTypeChanged(IdentityType identityType);
+    }
+}

--- a/app/src/main/java/zapsolutions/zap/customView/UserAvatarView.java
+++ b/app/src/main/java/zapsolutions/zap/customView/UserAvatarView.java
@@ -88,40 +88,23 @@ public class UserAvatarView extends ConstraintLayout {
         }
         */
 
-
         showAvatar();
-        showTorIdentity();
+        showIdentity(true);
     }
 
-    public void showTorIdentity() {
+    public void showIdentity(boolean tor) {
         if (mNodeUris != null) {
             if (mNodeUris.length > 1) {
                 for (int i = 0; i < mNodeUris.length; i++) {
-                    if (mNodeUris[i].getHost() != null && mNodeUris[i].getHost().toLowerCase().contains("onion")) {
-                        showIdentity(i);
-                        return;
+                    if (mNodeUris[i].getHost() != null ) {
+                        if(mNodeUris[i].getHost().toLowerCase().contains("onion") == tor) {
+                            showIdentity(i);
+                            return;
+                        }
                     }
-                    showIdentity(0);
                 }
-            } else {
-                showIdentity(0);
             }
-        }
-    }
-
-    public void showClearNetIdentity() {
-        if (mNodeUris != null) {
-            if (mNodeUris.length > 1) {
-                for (int i = 0; i < mNodeUris.length; i++) {
-                    if (mNodeUris[i].getHost() != null && !mNodeUris[i].getHost().toLowerCase().contains("onion")) {
-                        showIdentity(i);
-                        return;
-                    }
-                    showIdentity(0);
-                }
-            } else {
-                showIdentity(0);
-            }
+            showIdentity(0);
         }
     }
 

--- a/app/src/main/java/zapsolutions/zap/customView/UserAvatarView.java
+++ b/app/src/main/java/zapsolutions/zap/customView/UserAvatarView.java
@@ -97,7 +97,7 @@ public class UserAvatarView extends ConstraintLayout {
             if (mNodeUris.length > 1) {
                 for (int i = 0; i < mNodeUris.length; i++) {
                     if (mNodeUris[i].getHost() != null ) {
-                        if(mNodeUris[i].getHost().toLowerCase().contains("onion") == tor) {
+                        if(mNodeUris[i].isTorUri() == tor) {
                             showIdentity(i);
                             return;
                         }
@@ -183,7 +183,7 @@ public class UserAvatarView extends ConstraintLayout {
             return false;
         } else {
             if (mNodeUris[mCurrentUriId].getHost() != null) {
-                return mNodeUris[mCurrentUriId].getHost().toLowerCase().contains("onion");
+                return mNodeUris[mCurrentUriId].isTorUri();
             } else {
                 return false;
             }
@@ -198,9 +198,9 @@ public class UserAvatarView extends ConstraintLayout {
             boolean hasPublic = false;
             boolean hasTor = false;
             for (LightningNodeUri nodeUri : mNodeUris) {
-                if (nodeUri.getHost() != null && nodeUri.getHost().toLowerCase().contains("onion")) {
+                if (nodeUri.getHost() != null && nodeUri.isTorUri()) {
                     hasTor = true;
-                } else if (nodeUri.getHost() == null || !nodeUri.getHost().toLowerCase().contains("onion")) {
+                } else if (nodeUri.getHost() == null || !nodeUri.isTorUri()) {
                     hasPublic = true;
                 }
             }

--- a/app/src/main/java/zapsolutions/zap/lightning/LightningNodeUri.java
+++ b/app/src/main/java/zapsolutions/zap/lightning/LightningNodeUri.java
@@ -41,12 +41,19 @@ public class LightningNodeUri implements Serializable {
         return mImage;
     }
 
-    public String getAsString(){
+    public String getAsString() {
         String uri = mPubKey;
-        if (mHost != null){
+        if (mHost != null) {
             uri = uri + "@" + mHost;
         }
         return uri;
+    }
+
+    public boolean isTorUri() {
+        if (getHost() == null) {
+            return false;
+        }
+        return getHost().toLowerCase().contains("onion");
     }
 
     public static class Builder {

--- a/app/src/main/java/zapsolutions/zap/lightning/LightningNodeUri.java
+++ b/app/src/main/java/zapsolutions/zap/lightning/LightningNodeUri.java
@@ -41,6 +41,14 @@ public class LightningNodeUri implements Serializable {
         return mImage;
     }
 
+    public String getAsString(){
+        String uri = mPubKey;
+        if (mHost != null){
+            uri = uri + "@" + mHost;
+        }
+        return uri;
+    }
+
     public static class Builder {
         private String mPubKey;
         private String mHost;

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -58,6 +58,7 @@ import zapsolutions.zap.R;
 import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.lightning.LightningNodeUri;
+import zapsolutions.zap.lightning.LightningParser;
 
 import static zapsolutions.zap.util.UtilFunctions.hexStringToByteArray;
 
@@ -100,6 +101,7 @@ public class Wallet {
     private long mChannelBalancePendingOpen = 0;
     private long mChannelBalanceLimbo = 0;
     private String mIdentityPubKey;
+    private LightningNodeUri[] mNodeUris;
     private boolean mConnectedToLND = false;
     private boolean mInfoFetched = false;
     private boolean mBalancesFetched = false;
@@ -165,6 +167,7 @@ public class Wallet {
         mSyncedToChain = false;
         mTestnet = false;
         mIdentityPubKey = null;
+        mNodeUris = null;
         mLNDVersionString = "not connected";
         mHandler.removeCallbacksAndMessages(null);
         App.getAppContext().connectionToLNDEstablished = false;
@@ -196,6 +199,12 @@ public class Wallet {
                         mConnectedToLND = true;
                         mConnectionCheckInProgress = false;
                         mIdentityPubKey = infoResponse.getIdentityPubkey();
+                        if (mNodeUris == null) {
+                            mNodeUris = new LightningNodeUri[infoResponse.getUrisCount()];
+                            for (int i = 0; i < infoResponse.getUrisCount(); i++) {
+                                mNodeUris[i] = LightningParser.parseNodeUri(infoResponse.getUris(i));
+                            }
+                        }
                         broadcastLndConnectionTestResult(true, -1);
                     }, throwable -> {
                         mConnectionCheckInProgress = false;
@@ -351,6 +360,12 @@ public class Wallet {
                     mTestnet = infoResponse.getTestnet();
                     mLNDVersionString = infoResponse.getVersion();
                     mIdentityPubKey = infoResponse.getIdentityPubkey();
+                    if (mNodeUris == null) {
+                        mNodeUris = new LightningNodeUri[infoResponse.getUrisCount()];
+                        for (int i = 0; i < infoResponse.getUrisCount(); i++) {
+                            mNodeUris[i] = LightningParser.parseNodeUri(infoResponse.getUris(i));
+                        }
+                    }
                     mInfoFetched = true;
                     mConnectedToLND = true;
 
@@ -1177,6 +1192,10 @@ public class Wallet {
 
     public String getIdentityPubKey() {
         return mIdentityPubKey;
+    }
+
+    public LightningNodeUri[] getNodeUris() {
+        return mNodeUris;
     }
 
     private void setOnChainBalance(long total, long confirmed, long unconfirmed) {

--- a/app/src/main/res/layout/activity_identity.xml
+++ b/app/src/main/res/layout/activity_identity.xml
@@ -35,6 +35,16 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.35000002" />
 
+    <zapsolutions.zap.customView.IdentitySwitchView
+        android:id="@+id/identityTypeSwitcher"
+        android:layout_width="250dp"
+        android:layout_height="50dp"
+        android:layout_marginTop="25dp"
+        app:layout_constraintBottom_toTopOf="@id/hintButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/userAvatarView" />
+
     <Button
         android:id="@+id/hintButton"
         style="@style/Widget.AppCompat.Button.Borderless"
@@ -49,19 +59,19 @@
         android:textSize="14sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/userAvatarView" />
+        app:layout_constraintTop_toBottomOf="@+id/identityTypeSwitcher" />
 
     <TextView
         android:id="@+id/publicKey"
         android:layout_width="280dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="15dp"
+        android:text="@string/identity_explanation"
         android:textColor="@color/gray"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/userAvatarView"
-        android:text="@string/identity_explanation"
+        app:layout_constraintTop_toBottomOf="@id/identityTypeSwitcher"
         tools:visibility="visible" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/main/res/layout/view_identity_switch.xml
+++ b/app/src/main/res/layout/view_identity_switch.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/identitySwitchTabLayout"
+        android:layout_width="0dp"
+        android:layout_height="30dp"
+        android:background="@drawable/rounded_rectangle_seablue"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tabBackground="@drawable/tab_layout"
+        app:tabIndicatorHeight="0dp"
+        app:tabMode="fixed"
+        app:tabRippleColor="@null"
+        app:tabSelectedTextColor="@color/seaBlue">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/identity_switch_tor" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/identity_switch_public" />
+
+
+    </com.google.android.material.tabs.TabLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,7 +358,7 @@
     <string name="help_dialog_scanNodePublicKey">QR-Codes containing the following are valid:\n\n- pubkey\n- pubkey@host\n- pubkey@host:port</string>
     <string name="help_dialog_scanConnectionInfo">QR-Codes containing the following are valid:\n\n- Lndconnect string (lndconnect://...)\n- BtcPay Server connection (config=...)\n- Full content of your BTCPay Server config file</string>
     <string name="help_dialog_LightningVsOnChain">Lightning:\n\n+ instant\n+ low fees\n- not always possible\n\nPerfect for small transactions.\nUse whenever possible.\n\n\nOn-Chain:\n\n+ always possible\n- slower\n- higher fees\n\nGood for big transactions.\nUse this when Lightning is not possible.</string>
-    <string name="help_dialog_scanGeneric">Anything is allowed here.\nJust scan a QR-Code and Zap will automatically determine which action to take dependig on the data.</string>
+    <string name="help_dialog_scanGeneric">Anything is allowed here.\nJust scan a QR-Code and Zap will automatically determine which action to take depending on the data.</string>
 
     <string name="wallet_name">Wallet Name</string>
     <string name="delete">Delete</string>
@@ -408,4 +408,6 @@
     <string name="support_help_description">Visit our documentation.</string>
 
     <string name="identity_explanation">This is your identity on the lightning network!\nOthers can open a channel with you if they scan this QR-Code.</string>
+    <string name="identity_switch_tor">Tor</string>
+    <string name="identity_switch_public">Public</string>
 </resources>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the Identity screen so it shows the node uri instead of the pubkey.
A node can have more than one uri. If this is the case, the user is now able to switch between his tor and his public identity.
If only one identity is available, the switch will not be shown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase compatibility when letting other people open a channel to you using the identity screen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

My S9

## Screenshots (if appropriate):

![vid](https://user-images.githubusercontent.com/15313630/89061046-4f5e6c80-d364-11ea-93bd-e2e489a57269.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.