### PR TITLE
Crash fix on pasting short strings in scan activity

### DIFF
--- a/app/src/main/java/zapsolutions/zap/ScanActivity.java
+++ b/app/src/main/java/zapsolutions/zap/ScanActivity.java
@@ -85,7 +85,7 @@ public class ScanActivity extends BaseScannerActivity {
             LnurlDecoder.decode(data);
             readableDataFound(data);
             return;
-        } catch (LnurlDecoder.NoLnUrlDataException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/app/src/main/java/zapsolutions/zap/util/LnUrlUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/LnUrlUtil.java
@@ -63,6 +63,8 @@ public class LnUrlUtil {
             HttpClient.getInstance().addToRequestQueue(lnurlRequest, "LnUrlWithdrawRequest");
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
+            ZapLog.e(LOG_TAG, "LNURL is invalid. Decoding failed.");
+            listener.onError(ctx.getString(R.string.lnurl_decoding_no_lnurl_data), RefConstants.ERROR_DURATION_MEDIUM);
         } catch (LnurlDecoder.NoLnUrlDataException e) {
             listener.onNoLnUrlData();
         }

--- a/app/src/main/java/zapsolutions/zap/util/LnurlDecoder.java
+++ b/app/src/main/java/zapsolutions/zap/util/LnurlDecoder.java
@@ -11,7 +11,7 @@ public class LnurlDecoder {
         // Remove the "lightning:" uri scheme if it is present
         lnurl = UriUtil.removeURI(lnurl);
 
-        if (!lnurl.substring(0, 5).toLowerCase().equals("lnurl")) {
+        if (lnurl.length() < 5 || !lnurl.substring(0, 5).toLowerCase().equals("lnurl")) {
             throw new NoLnUrlDataException("LNURL decoding failed: The data to decode is not a LNURL");
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a crash when pasting strings shorter than 5 characters in the scan activity.
It also fixes a problem that on incorrect bech32 encoding of lnurls no error was shown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve stability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.