### PR TITLE
Update balance and channels on transaction events

### DIFF
--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -439,6 +439,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
         Wallet.getInstance().fetchChannelsFromLND();
 
         Wallet.getInstance().subscribeToTransactions();
+        Wallet.getInstance().subscribeToHtlcEvents();
         Wallet.getInstance().subscribeToInvoices();
 
         if (mHandler != null) {

--- a/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
@@ -182,7 +182,7 @@ public class InvoiceUtil {
                 .timeout(RefConstants.TIMEOUT_SHORT * TorUtil.getTorTimeoutMultiplier(), TimeUnit.SECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(paymentRequest -> {
-                    ZapLog.d(LOG_TAG, paymentRequest.toString());
+                    ZapLog.v(LOG_TAG, paymentRequest.toString());
 
                     if (paymentRequest.getTimestamp() + paymentRequest.getExpiry() < System.currentTimeMillis() / 1000) {
                         // Show error: payment request expired.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR triggers refetching balances from LND after every on-chain or off chain transaction.
It also triggers refetching channels from LND after every off chain transaction or forwarding event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is actually quite important. As we changed the UI to swiping between the home screen and the history, the fragments do not get recreated like before. Therefore the balances are no longer refetched from LND when going to the home screen.
Before this PR the balances only get refetched when the app is started or minimized and then maximized again.

This leads to displaying a wrong balance to the user after he has send a transaction for example.
But it goes even further. The calculations if the user has enough funds for example will also be done on wrong balances which leads to incorrect input validations.

With this PR all input validations should work correct again and the main balance is updated in real time.
Also you can now watch the balances of your channels shift on the channels page in real time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regtest with S9 and Nexus 4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.