### PR TITLE
Fix channel list bugs

### DIFF
--- a/app/src/main/java/zapsolutions/zap/channelManagement/ChannelItemAdapter.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ChannelItemAdapter.java
@@ -28,12 +28,12 @@ public class ChannelItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
         @Override
         public boolean areContentsTheSame(ChannelListItem oldItem, ChannelListItem newItem) {
-            return oldItem.equals(newItem);
+            return oldItem.equalsWithSameContent(newItem);
         }
 
         @Override
         public boolean areItemsTheSame(ChannelListItem item1, ChannelListItem item2) {
-            return item1.isSameChannel(item2);
+            return item1.equals(item2);
         }
 
         @Override

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ChannelListItem.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ChannelListItem.java
@@ -109,7 +109,19 @@ public abstract class ChannelListItem implements Comparable<ChannelListItem> {
             return false;
         }
 
-        return channelListItem.getChannelByteString().equals(this.getChannelByteString());
+        switch (this.getType()) {
+            case TYPE_OPEN_CHANNEL:
+                return ((OpenChannelItem) this).getChannel().getNumUpdates() == ((OpenChannelItem) channelListItem).getChannel().getNumUpdates();
+            case TYPE_PENDING_OPEN_CHANNEL:
+                return ((PendingOpenChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingOpenChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
+            case TYPE_PENDING_CLOSING_CHANNEL:
+                return ((PendingClosingChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingClosingChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
+            case TYPE_PENDING_FORCE_CLOSING_CHANNEL:
+                return ((PendingForceClosingChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingForceClosingChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
+            case TYPE_WAITING_CLOSE_CHANNEL:
+                return ((WaitingCloseChannelItem) this).getChannel().getChannel().getLocalBalance() == ((WaitingCloseChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
+        }
+        return false;
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ChannelListItem.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ChannelListItem.java
@@ -66,66 +66,72 @@ public abstract class ChannelListItem implements Comparable<ChannelListItem> {
         return ownAlias.compareTo(otherAlias);
     }
 
-    public boolean isSameChannel(@Nullable Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || obj.getClass() != this.getClass()) {
+    public boolean equalsWithSameContent(@Nullable Object obj) {
+        if (!equals(obj)) {
             return false;
         }
-        ChannelListItem channelListItem = (ChannelListItem) obj;
-        if (channelListItem.getType() != this.getType()) {
-            return false;
-        }
+
+        ChannelListItem that = (ChannelListItem) obj;
 
         switch (this.getType()) {
             case TYPE_OPEN_CHANNEL:
-                return ((OpenChannelItem) this).getChannel().getChanId() == ((OpenChannelItem) channelListItem).getChannel().getChanId();
+                return ((OpenChannelItem) this).getChannel().getNumUpdates() == ((OpenChannelItem) that).getChannel().getNumUpdates();
             case TYPE_PENDING_OPEN_CHANNEL:
-                return ((PendingOpenChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((PendingOpenChannelItem) channelListItem).getChannel().getChannel().getChannelPoint());
+                return ((PendingOpenChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingOpenChannelItem) that).getChannel().getChannel().getLocalBalance();
             case TYPE_PENDING_CLOSING_CHANNEL:
-                return ((PendingClosingChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((PendingClosingChannelItem) channelListItem).getChannel().getChannel().getChannelPoint());
+                return ((PendingClosingChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingClosingChannelItem) that).getChannel().getChannel().getLocalBalance();
             case TYPE_PENDING_FORCE_CLOSING_CHANNEL:
-                return ((PendingForceClosingChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((PendingForceClosingChannelItem) channelListItem).getChannel().getChannel().getChannelPoint());
+                return ((PendingForceClosingChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingForceClosingChannelItem) that).getChannel().getChannel().getLocalBalance();
             case TYPE_WAITING_CLOSE_CHANNEL:
-                return ((WaitingCloseChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((WaitingCloseChannelItem) channelListItem).getChannel().getChannel().getChannelPoint());
-        }
-
-        return channelListItem.getChannelByteString().equals(this.getChannelByteString());
-    }
-
-    @Override
-    public boolean equals(@Nullable Object obj) {
-
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || obj.getClass() != this.getClass()) {
-            return false;
-        }
-
-        ChannelListItem channelListItem = (ChannelListItem) obj;
-        if (channelListItem.getType() != this.getType()) {
-            return false;
-        }
-
-        switch (this.getType()) {
-            case TYPE_OPEN_CHANNEL:
-                return ((OpenChannelItem) this).getChannel().getNumUpdates() == ((OpenChannelItem) channelListItem).getChannel().getNumUpdates();
-            case TYPE_PENDING_OPEN_CHANNEL:
-                return ((PendingOpenChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingOpenChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
-            case TYPE_PENDING_CLOSING_CHANNEL:
-                return ((PendingClosingChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingClosingChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
-            case TYPE_PENDING_FORCE_CLOSING_CHANNEL:
-                return ((PendingForceClosingChannelItem) this).getChannel().getChannel().getLocalBalance() == ((PendingForceClosingChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
-            case TYPE_WAITING_CLOSE_CHANNEL:
-                return ((WaitingCloseChannelItem) this).getChannel().getChannel().getLocalBalance() == ((WaitingCloseChannelItem) channelListItem).getChannel().getChannel().getLocalBalance();
+                return ((WaitingCloseChannelItem) this).getChannel().getChannel().getLocalBalance() == ((WaitingCloseChannelItem) that).getChannel().getChannel().getLocalBalance();
         }
         return false;
     }
 
     @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        ChannelListItem that = (ChannelListItem) obj;
+        if (that.getType() != this.getType()) {
+            return false;
+        }
+
+        switch (this.getType()) {
+            case TYPE_OPEN_CHANNEL:
+                return ((OpenChannelItem) this).getChannel().getChanId() == ((OpenChannelItem) that).getChannel().getChanId();
+            case TYPE_PENDING_OPEN_CHANNEL:
+                return ((PendingOpenChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((PendingOpenChannelItem) that).getChannel().getChannel().getChannelPoint());
+            case TYPE_PENDING_CLOSING_CHANNEL:
+                return ((PendingClosingChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((PendingClosingChannelItem) that).getChannel().getChannel().getChannelPoint());
+            case TYPE_PENDING_FORCE_CLOSING_CHANNEL:
+                return ((PendingForceClosingChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((PendingForceClosingChannelItem) that).getChannel().getChannel().getChannelPoint());
+            case TYPE_WAITING_CLOSE_CHANNEL:
+                return ((WaitingCloseChannelItem) this).getChannel().getChannel().getChannelPoint().equals(((WaitingCloseChannelItem) that).getChannel().getChannel().getChannelPoint());
+            default:
+                return false;
+        }
+    }
+
+    @Override
     public int hashCode() {
-        return this.getChannelByteString().hashCode();
+        switch (this.getType()) {
+            case TYPE_OPEN_CHANNEL:
+                return Long.valueOf(((OpenChannelItem) this).getChannel().getChanId()).hashCode();
+            case TYPE_PENDING_OPEN_CHANNEL:
+                return ((PendingOpenChannelItem) this).getChannel().getChannel().getChannelPoint().hashCode();
+            case TYPE_PENDING_CLOSING_CHANNEL:
+                return ((PendingClosingChannelItem) this).getChannel().getChannel().getChannelPoint().hashCode();
+            case TYPE_PENDING_FORCE_CLOSING_CHANNEL:
+                return ((PendingForceClosingChannelItem) this).getChannel().getChannel().getChannelPoint().hashCode();
+            case TYPE_WAITING_CLOSE_CHANNEL:
+                return ((WaitingCloseChannelItem) this).getChannel().getChannel().getChannelPoint().hashCode();
+            default:
+                return 0;
+        }
     }
 }

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ChannelViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ChannelViewHolder.java
@@ -19,6 +19,7 @@ public class ChannelViewHolder extends RecyclerView.ViewHolder {
     TextView mStatus;
     ImageView mStatusDot;
     View mRootView;
+    View mContentView;
     Context mContext;
     private ChannelSelectListener mChannelSelectListener;
     private TextView mRemoteName;
@@ -39,7 +40,8 @@ public class ChannelViewHolder extends RecyclerView.ViewHolder {
         mCapacity = itemView.findViewById(R.id.capacity);
         mLocalBar = itemView.findViewById(R.id.localBar);
         mRemoteBar = itemView.findViewById(R.id.remoteBar);
-        mRootView = itemView.findViewById(R.id.transactionRootView);
+        mRootView = itemView.findViewById(R.id.channelRootView);
+        mContentView = itemView.findViewById(R.id.channelContent);
         mContext = itemView.getContext();
     }
 

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ManageChannelsActivity.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ManageChannelsActivity.java
@@ -41,6 +41,7 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
     private TextView mEmptyListText;
     private SwipeRefreshLayout mSwipeRefreshLayout;
     private List<ChannelListItem> mChannelItems;
+    private String mCurrentSearchString = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -74,7 +75,7 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
 
         // Refetch channels from LND. This will automatically update the view when finished.
         // This is necessary, as we might display outdated data otherwise.
-        if(WalletConfigsManager.getInstance().hasAnyConfigs()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             Wallet.getInstance().fetchChannelsFromLND();
         }
     }
@@ -142,7 +143,12 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
         }
 
         // Update the view
-        mAdapter.replaceAll(mChannelItems);
+        if (mCurrentSearchString.isEmpty()) {
+            mAdapter.replaceAll(mChannelItems);
+        } else {
+            final List<ChannelListItem> filteredContactList = filter(mChannelItems, mCurrentSearchString);
+            mAdapter.replaceAll(filteredContactList);
+        }
     }
 
     @Override
@@ -198,8 +204,7 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
 
     @Override
     public void onRefresh() {
-
-        if(WalletConfigsManager.getInstance().hasAnyConfigs()) {
+        if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
             Wallet.getInstance().fetchChannelsFromLND();
         } else {
             mSwipeRefreshLayout.setRefreshing(false);
@@ -221,11 +226,10 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
 
             @Override
             public boolean onQueryTextChange(String newText) {
-
+                mCurrentSearchString = newText;
                 final List<ChannelListItem> filteredContactList = filter(mChannelItems, newText);
                 mAdapter.replaceAll(filteredContactList);
                 mRecyclerView.scrollToPosition(0);
-
                 return true;
             }
         });

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ManageChannelsActivity.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ManageChannelsActivity.java
@@ -227,8 +227,8 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
             @Override
             public boolean onQueryTextChange(String newText) {
                 mCurrentSearchString = newText;
-                final List<ChannelListItem> filteredContactList = filter(mChannelItems, newText);
-                mAdapter.replaceAll(filteredContactList);
+                final List<ChannelListItem> filteredChannelList = filter(mChannelItems, newText);
+                mAdapter.replaceAll(filteredChannelList);
                 mRecyclerView.scrollToPosition(0);
                 return true;
             }
@@ -247,31 +247,29 @@ public class ManageChannelsActivity extends BaseAppCompatActivity implements Cha
             switch (item.getType()) {
                 case ChannelListItem.TYPE_OPEN_CHANNEL:
                     pubkey = ((OpenChannelItem) item).getChannel().getRemotePubkey();
-                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this).toLowerCase();
+                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this);
                     break;
                 case ChannelListItem.TYPE_PENDING_OPEN_CHANNEL:
                     pubkey = ((PendingOpenChannelItem) item).getChannel().getChannel().getRemoteNodePub();
-                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this).toLowerCase();
+                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this);
                     break;
                 case ChannelListItem.TYPE_PENDING_CLOSING_CHANNEL:
                     pubkey = ((PendingClosingChannelItem) item).getChannel().getChannel().getRemoteNodePub();
-                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this).toLowerCase();
+                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this);
                     break;
                 case ChannelListItem.TYPE_PENDING_FORCE_CLOSING_CHANNEL:
                     pubkey = ((PendingForceClosingChannelItem) item).getChannel().getChannel().getRemoteNodePub();
-                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this).toLowerCase();
+                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this);
                     break;
                 case ChannelListItem.TYPE_WAITING_CLOSE_CHANNEL:
                     pubkey = ((WaitingCloseChannelItem) item).getChannel().getChannel().getRemoteNodePub();
-                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this).toLowerCase();
+                    text = pubkey + Wallet.getInstance().getNodeAliasFromPubKey(pubkey, ManageChannelsActivity.this);
                     break;
-                case ChannelListItem.TYPE_CLOSED_CHANNEL:
-                    text = "";
                 default:
                     text = "";
             }
 
-            if (text.contains(lowerCaseQuery)) {
+            if (text.toLowerCase().contains(lowerCaseQuery)) {
                 filteredItemList.add(item);
             }
         }

--- a/app/src/main/java/zapsolutions/zap/channelManagement/OpenChannelViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/OpenChannelViewHolder.java
@@ -17,11 +17,11 @@ public class OpenChannelViewHolder extends ChannelViewHolder {
         if (isActive) {
             mStatus.setText(R.string.channel_state_open);
             mStatusDot.setImageTintList(ColorStateList.valueOf(ContextCompat.getColor(mContext, R.color.superGreen)));
-            mRootView.setAlpha(1f);
+            mContentView.setAlpha(1f);
         } else {
             mStatus.setText(R.string.channel_state_offline);
             mStatusDot.setImageTintList(ColorStateList.valueOf(ContextCompat.getColor(mContext, R.color.gray)));
-            mRootView.setAlpha(0.65f);
+            mContentView.setAlpha(0.65f);
         }
     }
 

--- a/app/src/main/java/zapsolutions/zap/channelManagement/PendingChannelViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/PendingChannelViewHolder.java
@@ -25,7 +25,7 @@ public abstract class PendingChannelViewHolder extends ChannelViewHolder {
     private void setState() {
         mStatus.setText(getStatusText());
         mStatusDot.setImageTintList(ColorStateList.valueOf(ContextCompat.getColor(mContext, getStatusColor())));
-        mRootView.setAlpha(0.65f);
+        mContentView.setAlpha(0.65f);
     }
 
     void bindPendingChannelItem(PendingChannelsResponse.PendingChannel pendingChannel) {

--- a/app/src/main/res/layout/channel_list_element_channel.xml
+++ b/app/src/main/res/layout/channel_list_element_channel.xml
@@ -2,192 +2,197 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/transactionRootView"
+    android:id="@+id/channelRootView"
     android:layout_width="match_parent"
     android:layout_height="120dp"
     android:layout_marginStart="10dp"
     android:layout_marginTop="10dp"
     android:layout_marginEnd="10dp"
     android:layout_marginBottom="10dp"
-    android:background="@drawable/bg_clickable_item"
     android:gravity="center_vertical">
 
-    <TextView
-        android:id="@+id/remoteName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:ellipsize="end"
-        android:maxWidth="200dp"
-        android:maxLines="1"
-        android:textSize="18sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="RemoteName" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/channelContent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/bg_clickable_item">
 
-    <TextView
-        android:id="@+id/state"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="5dp"
-        android:layout_weight="1"
-        app:layout_constraintEnd_toStartOf="@id/statusDot"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Status" />
-
-    <ImageView
-        android:id="@+id/statusDot"
-        android:layout_width="10dp"
-        android:layout_height="10dp"
-        android:layout_marginEnd="8dp"
-        app:layout_constraintBottom_toBottomOf="@+id/state"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/state"
-        app:srcCompat="@drawable/ic_status_dot_black_24dp" />
-
-    <ImageView
-        android:id="@+id/imageView3"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="4dp"
-        android:layout_marginEnd="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/remoteName"
-        app:srcCompat="@color/gray" />
-
-    <LinearLayout
-        android:id="@+id/linearLayout3"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/remoteName">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:id="@+id/localBalanceTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/channel_local_balance"
-                android:textSize="12sp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/capacityTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
-                android:text="@string/channel_capacity"
-                android:textSize="12sp"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/remoteBalanceTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/channel_remote_balance"
-                android:textSize="12sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/remoteName"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:minHeight="16dp">
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:maxWidth="200dp"
+            android:maxLines="1"
+            android:textSize="18sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="RemoteName" />
 
-            <ProgressBar
-                android:id="@+id/localBar"
-                style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="0dp"
-                android:layout_height="6dp"
-                android:layout_marginEnd="5dp"
-                android:progressDrawable="@drawable/channel_local_balance_progress_bar"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/lightningIcon"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <TextView
+            android:id="@+id/state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="5dp"
+            android:layout_weight="1"
+            app:layout_constraintEnd_toStartOf="@id/statusDot"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Status" />
 
-            <ImageView
-                android:id="@+id/lightningIcon"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_gravity="center"
-                android:tint="@color/lightningOrange"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/bolt_black_filled_24dp" />
+        <ImageView
+            android:id="@+id/statusDot"
+            android:layout_width="10dp"
+            android:layout_height="10dp"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintBottom_toBottomOf="@+id/state"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/state"
+            app:srcCompat="@drawable/ic_status_dot_black_24dp" />
 
-            <ProgressBar
-                android:id="@+id/remoteBar"
-                style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="0dp"
-                android:layout_height="6dp"
-                android:layout_marginStart="5dp"
-                android:layoutDirection="rtl"
-                android:progressDrawable="@drawable/channel_remote_balance_progress_bar"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/lightningIcon"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/imageView3"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/remoteName"
+            app:srcCompat="@color/gray" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        <LinearLayout
+            android:id="@+id/linearLayout3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/remoteName">
 
-            <TextView
-                android:id="@+id/localBalance"
-                android:layout_width="wrap_content"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/localBalanceTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/channel_local_balance"
+                    android:textSize="12sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/capacityTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/channel_capacity"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/remoteBalanceTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/channel_remote_balance"
+                    android:textSize="12sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="2500 sat"
-                android:textSize="12sp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:minHeight="16dp">
 
-            <TextView
-                android:id="@+id/capacity"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
-                android:textSize="12sp"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="Capacity" />
+                <ProgressBar
+                    android:id="@+id/localBar"
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="0dp"
+                    android:layout_height="6dp"
+                    android:layout_marginEnd="5dp"
+                    android:progressDrawable="@drawable/channel_local_balance_progress_bar"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/lightningIcon"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/remoteBalance"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="12sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="1000 sat" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <ImageView
+                    android:id="@+id/lightningIcon"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:tint="@color/lightningOrange"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:srcCompat="@drawable/bolt_black_filled_24dp" />
 
-    </LinearLayout>
+                <ProgressBar
+                    android:id="@+id/remoteBar"
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="0dp"
+                    android:layout_height="6dp"
+                    android:layout_marginStart="5dp"
+                    android:layoutDirection="rtl"
+                    android:progressDrawable="@drawable/channel_remote_balance_progress_bar"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/lightningIcon"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/localBalance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="12sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="2500 sat" />
+
+                <TextView
+                    android:id="@+id/capacity"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="Capacity" />
+
+                <TextView
+                    android:id="@+id/remoteBalance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="12sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="1000 sat" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes 3 minor bugs on the channel list.

1. Channels were always recognized as having different content when refreshing channels. The reason for this is that the channel byte string we used for comparison contains the uptime of the channel which of course is always different. This caused the update animation to play although it was not necessary.

2. If channels get refetched while the user was searching, channels that did not match the search string got added. This is now fixed.

3. The faded transparency for offline and pending channels did interfer with the new animations and sometimes was displayed incorrect. This is now fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve user experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regtest S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.