### PR TITLE
Read payment memo without LND

### DIFF
--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnPaymentItem.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnPaymentItem.java
@@ -3,12 +3,20 @@ package zapsolutions.zap.transactionHistory.listItems;
 import com.github.lightningnetwork.lnd.lnrpc.Payment;
 import com.google.protobuf.ByteString;
 
+import zapsolutions.zap.util.PaymentRequestUtil;
+
 public class LnPaymentItem extends TransactionItem {
     private Payment mPayment;
+    private String mMemo;
 
     public LnPaymentItem(Payment payment) {
         mPayment = payment;
         mCreationDate = payment.getCreationDate();
+
+        if (payment.getPaymentRequest() != null && !payment.getPaymentRequest().isEmpty()) {
+            // This will only be true for payments done with LND 0.7.0-beta and later
+            mMemo = PaymentRequestUtil.getMemo(payment.getPaymentRequest());
+        }
     }
 
     @Override
@@ -23,5 +31,9 @@ public class LnPaymentItem extends TransactionItem {
     @Override
     public ByteString getTransactionByteString() {
         return mPayment.toByteString();
+    }
+
+    public String getMemo() {
+        return mMemo;
     }
 }

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnPaymentViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnPaymentViewHolder.java
@@ -3,12 +3,8 @@ package zapsolutions.zap.transactionHistory.listItems;
 import android.content.SharedPreferences;
 import android.view.View;
 
-import com.github.lightningnetwork.lnd.lnrpc.PayReqString;
-
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import zapsolutions.zap.R;
-import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
-import zapsolutions.zap.util.ZapLog;
 
 public class LnPaymentViewHolder extends TransactionViewHolder {
 
@@ -36,32 +32,15 @@ public class LnPaymentViewHolder extends TransactionViewHolder {
         setPrimaryDescription(mContext.getResources().getString(R.string.sent));
         setAmount(lnPaymentItem.getPayment().getValueSat() * -1, true);
         setFee(lnPaymentItem.getPayment().getFee(), true);
-        setSecondaryDescription("", false);
 
-        if (!lnPaymentItem.getPayment().getPaymentRequest().isEmpty()) {
-            // This will only be true for payments done with LND 0.7.0-beta and later
-            decodeLightningInvoice(lnPaymentItem.getPayment().getPaymentRequest());
+        if (lnPaymentItem.getMemo() == null) {
+            setSecondaryDescription("", false);
+        } else {
+            setSecondaryDescription(lnPaymentItem.getMemo(), true);
         }
 
         // Set on click listener
         setOnRootViewClickListener(lnPaymentItem, HistoryListItem.TYPE_LN_PAYMENT);
-    }
-
-    private void decodeLightningInvoice(String invoice) {
-
-        // decode lightning invoice
-        PayReqString decodePaymentRequest = PayReqString.newBuilder()
-                .setPayReq(invoice)
-                .build();
-
-        if (mCompositeDisposable != null && !mCompositeDisposable.isDisposed())
-            mCompositeDisposable.add(LndConnection.getInstance().getLightningService().decodePayReq(decodePaymentRequest)
-                    .subscribe(payReq -> {
-                        if (!payReq.getDescription().isEmpty()) {
-                            // Set description
-                            setSecondaryDescription(payReq.getDescription(), true);
-                        }
-                    }, throwable -> ZapLog.d(LOG_TAG, "Decode payment request failed: " + throwable.fillInStackTrace())));
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/util/Bech32.java
+++ b/app/src/main/java/zapsolutions/zap/util/Bech32.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 
 public class Bech32 {
 
-    private static final String CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+    public static final String CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
     public static String bech32Encode(String hrp, byte[] data) {
 
@@ -155,6 +155,28 @@ public class Bech32 {
         }
 
         return ret;
+    }
+
+    public static byte[] regroupBytes(byte[] bytes) {
+        // regroups the "5 bit" bytes to 8 bit bytes.
+        boolean[] bitArray = new boolean[bytes.length * 5];
+        for (int i = 0; i < bytes.length; i++) {
+            for (int j = 3; j < 8; j++)
+                bitArray[i * 5 + j - 3] = (bytes[i] & (byte) (128 / Math.pow(2, j))) != 0;
+        }
+        return bitArrayToBytes(bitArray);
+    }
+
+    private static byte[] bitArrayToBytes(boolean[] input) {
+        byte[] toReturn = new byte[input.length / 8];
+        for (int entry = 0; entry < toReturn.length; entry++) {
+            for (int bit = 0; bit < 8; bit++) {
+                if (input[entry * 8 + bit]) {
+                    toReturn[entry] |= (128 >> bit);
+                }
+            }
+        }
+        return toReturn;
     }
 
 }

--- a/app/src/main/java/zapsolutions/zap/util/LnurlDecoder.java
+++ b/app/src/main/java/zapsolutions/zap/util/LnurlDecoder.java
@@ -18,35 +18,13 @@ public class LnurlDecoder {
         String decodedLnurl = null;
         try {
             byte[] decodedBech32 = Bech32.bech32Decode(lnurl, false).second;
+            byte[] regroupedBytes = Bech32.regroupBytes(decodedBech32);
 
-            // Translate the bytes to 5 bit groups, most significant bit first.
-            boolean[] bitArray = new boolean[decodedBech32.length * 5];
-            for (int i = 0; i < decodedBech32.length; i++) {
-                for (int j = 3; j < 8; j++)
-                    bitArray[i * 5 + j - 3] = (decodedBech32[i] & (byte) (128 / Math.pow(2, j))) != 0;
-            }
-
-            // Re-arrange those bits into groups of 8 bits.
-            byte[] regroupedBits = booleanArrayToBytes(bitArray);
-
-            decodedLnurl = new String(regroupedBits);
+            decodedLnurl = new String(regroupedBytes);
         } catch (Exception e) {
             throw new IllegalArgumentException("LNURL decoding failed: " + e.getMessage());
         }
         return decodedLnurl;
-    }
-
-    private static byte[] booleanArrayToBytes(boolean[] input) {
-        byte[] toReturn = new byte[input.length / 8];
-        for (int entry = 0; entry < toReturn.length; entry++) {
-            for (int bit = 0; bit < 8; bit++) {
-                if (input[entry * 8 + bit]) {
-                    toReturn[entry] |= (128 >> bit);
-                }
-            }
-        }
-
-        return toReturn;
     }
 
     public static class NoLnUrlDataException extends Exception {

--- a/app/src/main/java/zapsolutions/zap/util/PaymentRequestUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PaymentRequestUtil.java
@@ -1,0 +1,53 @@
+package zapsolutions.zap.util;
+
+import androidx.annotation.NonNull;
+
+import java.util.Arrays;
+
+public class PaymentRequestUtil {
+    private static final String LOG_TAG = PaymentRequestUtil.class.getName();
+
+    public static String getMemo(@NonNull String paymentRequest) {
+        try {
+            // Extract the tagged data fields in the bech32 encoded string.
+            // Start: position of bech32 separator "1" + 1 + timestamp (7)
+            // End: length - checksum (6) - signature (104)
+            String taggedPart = paymentRequest.substring(paymentRequest.lastIndexOf("1") + 1 + 7, paymentRequest.length() - 6 - 104);
+
+            byte[] decodedBech32 = Bech32.bech32Decode(paymentRequest, false).second;
+
+            // Extract tagged data fields in decoded byte array
+            byte[] decodedTaggedPart = Arrays.copyOfRange(decodedBech32, 7, decodedBech32.length - 104);
+
+            // Find start and end index of memo data
+            int start = 0, end = 0;
+            int index = 0;
+            while (index < taggedPart.length()) {
+                boolean isMemo = taggedPart.charAt(index) == 'd';
+                int currentDataFieldLength = getTaggedDataFieldLength(taggedPart.substring(index + 1, index + 3));
+                if (isMemo) {
+                    start = index + 3;
+                    end = index + 3 + currentDataFieldLength;
+                    break;
+                }
+                index = index + 3 + currentDataFieldLength;
+            }
+
+            if (start != 0) {
+                byte[] decodedMemoPart = Arrays.copyOfRange(decodedTaggedPart, start, end);
+                return new String(Bech32.regroupBytes(decodedMemoPart));
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            ZapLog.w(LOG_TAG, "Error while trying to read memo of " + paymentRequest);
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private static int getTaggedDataFieldLength(String lengthString) {
+        return Bech32.CHARSET.indexOf(lengthString.charAt(0)) * 32 + Bech32.CHARSET.indexOf(lengthString.charAt(1));
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this PR we are now able to read the Memo/Description without using LND.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the transaction history there were "glitches" of popping up descriptions for ln payments, as they were loaded in an async way.
This is now gone and it looks nice.
But the main reason for this change is that we can now make the ln payments searchable by their memo in the furure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.