### PR TITLE
Bugfixes

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -251,7 +251,7 @@ public class SendBSDFragment extends RxBSDFragment {
                         mBtnSend.setEnabled(true);
                         mBtnSend.setTextColor(getResources().getColor(R.color.lightningOrange));
                     }
-                    if (currentValue == 0) {
+                    if (currentValue == 0 && mFixedAmount == 0L) {
                         mBtnSend.setEnabled(false);
                         mBtnSend.setTextColor(getResources().getColor(R.color.gray));
                     }

--- a/app/src/main/java/zapsolutions/zap/lnurl/channel/LnUrlChannelBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/lnurl/channel/LnUrlChannelBSDFragment.java
@@ -29,6 +29,7 @@ import androidx.transition.ChangeBounds;
 import androidx.transition.Transition;
 import androidx.transition.TransitionManager;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.toolbox.StringRequest;
 import com.github.lightningnetwork.lnd.lnrpc.ConnectPeerRequest;
@@ -47,7 +48,6 @@ import java.util.concurrent.TimeUnit;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import zapsolutions.zap.R;
-import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.connection.HttpClient;
 import zapsolutions.zap.connection.establishConnectionToLnd.LndConnection;
 import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
@@ -302,6 +302,10 @@ public class LnUrlChannelBSDFragment extends RxBSDFragment {
                     ZapLog.e(TAG, "Final request failed");
                     switchToFailedScreen("Final request failed");
                 });
+
+        // Make sure this request is executed only once and it doesn't timeout to fast.
+        // If this is not done, then it can happen that Zap shows an error although everything was executed.
+        lnUrlRequest.setRetryPolicy(new DefaultRetryPolicy(30000, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
 
         // Send final request to LNURL service
         HttpClient.getInstance().addToRequestQueue(lnUrlRequest, "LnUrlFinalChannelRequest");

--- a/app/src/main/java/zapsolutions/zap/lnurl/withdraw/LnUrlWithdrawBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/lnurl/withdraw/LnUrlWithdrawBSDFragment.java
@@ -34,6 +34,7 @@ import androidx.transition.ChangeBounds;
 import androidx.transition.Transition;
 import androidx.transition.TransitionManager;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.toolbox.StringRequest;
 import com.github.lightningnetwork.lnd.lnrpc.Invoice;
@@ -310,7 +311,6 @@ public class LnUrlWithdrawBSDFragment extends RxBSDFragment {
                         .setExpiry(60L) // in seconds
                         .build();
 
-
                 getCompositeDisposable().add(LndConnection.getInstance().getLightningService().addInvoice(asyncInvoiceRequest)
                         .subscribe(addInvoiceResponse -> {
 
@@ -331,6 +331,10 @@ public class LnUrlWithdrawBSDFragment extends RxBSDFragment {
                                             switchToFailedScreen(getResources().getString(R.string.lnurl_service_not_responding, host));
                                         }
                                     });
+
+                            // Make sure this request is executed only once and it doesn't timeout to fast.
+                            // If this is not done, then it can happen that Zap shows an error although everything was executed.
+                            lnUrlRequest.setRetryPolicy(new DefaultRetryPolicy(30000, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
 
                             // Send final request to LNURL service
                             HttpClient.getInstance().addToRequestQueue(lnUrlRequest, "LnUrlFinalWithdrawRequest");

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/TransactionHistoryFragment.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/TransactionHistoryFragment.java
@@ -53,7 +53,7 @@ import zapsolutions.zap.util.ZapLog;
 /**
  * A simple {@link Fragment} subclass.
  */
-public class TransactionHistoryFragment extends Fragment implements Wallet.HistoryListener, Wallet.InvoiceSubscriptionListener, Wallet.TransactionSubscriptionListener, SwipeRefreshLayout.OnRefreshListener, TransactionSelectListener {
+public class TransactionHistoryFragment extends Fragment implements Wallet.HistoryListener, Wallet.InvoiceSubscriptionListener, SwipeRefreshLayout.OnRefreshListener, TransactionSelectListener {
 
     private static final String LOG_TAG = TransactionHistoryFragment.class.getName();
 
@@ -145,7 +145,6 @@ public class TransactionHistoryFragment extends Fragment implements Wallet.Histo
         // Register listeners
         Wallet.getInstance().registerHistoryListener(this);
         Wallet.getInstance().registerInvoiceSubscriptionListener(this);
-        Wallet.getInstance().registerTransactionSubscriptionListener(this);
 
 
         // use a linear layout manager
@@ -356,7 +355,6 @@ public class TransactionHistoryFragment extends Fragment implements Wallet.Histo
         // Unregister listeners
         Wallet.getInstance().unregisterHistoryListener(this);
         Wallet.getInstance().unregisterInvoiceSubscriptionListener(this);
-        Wallet.getInstance().unregisterTransactionSubscriptionListener(this);
     }
 
     @Override
@@ -391,22 +389,6 @@ public class TransactionHistoryFragment extends Fragment implements Wallet.Histo
         // Add dateline if necessary
         DateItem dateItem = new DateItem(item.mCreationDate);
         mAdapter.add(dateItem);
-    }
-
-    @Override
-    public void onTransactionEvent(Transaction transaction) {
-        int tempCount = mAdapter.getItemCount();
-        OnChainTransactionItem item = new OnChainTransactionItem(transaction);
-        mHistoryItems.add(item);
-        mAdapter.add(item);
-
-        // Add dateline if necessary
-        DateItem dateItem = new DateItem(item.mCreationDate);
-        mAdapter.add(dateItem);
-        
-        if (tempCount != mAdapter.getItemCount()) {
-            mRecyclerView.scrollToPosition(0);
-        }
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
@@ -70,7 +70,7 @@ public class InvoiceUtil {
             // Check if the invoice is for the same network the app is connected to
             switch (Wallet.getInstance().getNetwork()) {
                 case MAINNET:
-                    if (hasPrefix(INVOICE_PREFIX_LIGHTNING_MAINNET, lnInvoice)) {
+                    if (hasPrefix(INVOICE_PREFIX_LIGHTNING_MAINNET, lnInvoice) && !hasPrefix(INVOICE_PREFIX_LIGHTNING_REGTEST, lnInvoice)) {
                         decodeLightningInvoice(ctx, listener, lnInvoice, compositeDisposable);
                     } else {
                         // Show error. Please use a MAINNET invoice.

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -191,6 +191,8 @@ public class Wallet {
 
             mConnectionCheckInProgress = true;
             mIsWalletReady = false;
+            mBalancesFetched = false;
+            mChannelsFetched = false;
 
             ZapLog.d(LOG_TAG, "LND connection test.");
 

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -190,6 +190,7 @@ public class Wallet {
         if (!mConnectionCheckInProgress) {
 
             mConnectionCheckInProgress = true;
+            mIsWalletReady = false;
 
             ZapLog.d(LOG_TAG, "LND connection test.");
 

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -795,13 +795,7 @@ public class Wallet {
         compositeDisposable.add(LndConnection.getInstance().getLightningService().subscribeTransactions(GetTransactionsRequest.newBuilder().build())
                 .subscribe(transaction -> {
                     ZapLog.d(LOG_TAG, "Received transaction subscription event.");
-
-                    // update internal transaction list
-                    compositeDisposable.add(LndConnection.getInstance().getLightningService().getTransactions(GetTransactionsRequest.newBuilder().build())
-                            .subscribe(transactionDetails -> {
-                                mOnChainTransactionList = Lists.reverse(transactionDetails.getTransactionsList());
-                            }, throwable -> ZapLog.e(LOG_TAG, "Exception in transaction request task: " + throwable.getMessage())));
-
+                    fetchTransactionsFromLND(); // update internal transaction list
                     fetchBalancesWithDebounce(); // Always update balances if a transaction event occurs.
                     broadcastTransactionUpdate(transaction);
                 }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR includes 5 bugfixes.

- With LNURL-Withdraw and LNURL-Channel it could happen that a failed message was displayed although it worked. This is now fixed.
- Uri handling only worked when freshly starting the app. Now Uri handling also fires when the app was already open and is just brought to foreground.
- For very small values it could happen that the pay button was disabled when switching currencies on the payment dialog.
- When scanning regtest invoices from mainnet a wrong error message was shown.
- Due to transaction timestamp changing after first confirmation a confirmed transaction could appear twice in the history list.
