### PR TITLE
Prevent clipboard popup for data copied in zap

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/ClipBoardUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/ClipBoardUtil.java
@@ -32,6 +32,10 @@ public class ClipBoardUtil {
             ClipData clip = ClipData.newPlainText(label, data);
             clipboard.setPrimaryClip(clip);
             Toast.makeText(context, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show();
+
+            // Make sure the data just copied to clipboard does not trigger a clipboard scan popup
+            String clipboardContentHash = UtilFunctions.sha256Hash(data.toString());
+            PrefsUtil.edit().putString(PrefsUtil.LAST_CLIPBOARD_SCAN, clipboardContentHash).apply();
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR prevents zap from showing a popup for clipboard content that was actually copied from zap itself.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent unnecessary / irritating popups.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my S9