### PR TITLE
Improve address validation

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
@@ -28,7 +28,6 @@ public class InvoiceUtil {
     public static ArrayList<String> ADDRESS_PREFIX_ONCHAIN_TESTNET = new ArrayList<>(Arrays.asList("m", "n", "2", "tb1"));
     public static ArrayList<String> ADDRESS_PREFIX_ONCHAIN_REGTEST = new ArrayList<>(Arrays.asList("m", "n", "2", "bcrt1"));
     private static int INVOICE_LIGHTNING_MIN_LENGTH = 6;
-    private static int ADDRESS_ON_CHAIN_MIN_LENGTH = 5;
 
 
     public static boolean isLightningInvoice(@NonNull String data) {
@@ -40,14 +39,18 @@ public class InvoiceUtil {
     }
 
     public static boolean isBitcoinAddress(@NonNull String data) {
-        if (data.isEmpty() || data.length() < ADDRESS_ON_CHAIN_MIN_LENGTH) {
+        if (data.isEmpty()) {
             return false;
         }
-        ArrayList<String> prefixes = new ArrayList<>();
-        prefixes.addAll(ADDRESS_PREFIX_ONCHAIN_MAINNET);
-        prefixes.addAll(ADDRESS_PREFIX_ONCHAIN_TESTNET);
-        prefixes.addAll(ADDRESS_PREFIX_ONCHAIN_REGTEST);
-        return hasPrefix(prefixes, data);
+        return (isBase58Address(data) || isBech32Address(data));
+    }
+
+    public static boolean isBase58Address(String input) {
+        return input.matches("^[123mn][a-km-zA-HJ-NP-Z1-9]{25,34}$");
+    }
+
+    public static boolean isBech32Address(String input) {
+        return input.matches("^((bc1|tb1|bcrt1)[ac-hj-np-z02-9]{11,71}|(BC1|TB1|BCRT1)[AC-HJ-NP-Z02-9]{11,71})$");
     }
 
     public static void readInvoice(Context ctx, CompositeDisposable compositeDisposable, String data, OnReadInvoiceCompletedListener listener) {
@@ -214,7 +217,6 @@ public class InvoiceUtil {
         if (data.isEmpty()) {
             return false;
         }
-        boolean hasPrefix = false;
         for (String prefix : prefixes) {
             if (data.length() >= prefix.length()) {
                 if (data.substring(0, prefix.length()).equalsIgnoreCase(prefix)) {

--- a/app/src/test/java/zapsolutions/zap/util/InvoiceUtilTest.java
+++ b/app/src/test/java/zapsolutions/zap/util/InvoiceUtilTest.java
@@ -28,4 +28,28 @@ public class InvoiceUtilTest {
         assertFalse(InvoiceUtil.isLightningInvoice(arbitraryString));
     }
 
+    @Test
+    public void givenBitcoinAddress_whenIsBitcoinAddress_ThenIsBitcoinAddressReturnTrue() {
+        // example addresses taken from: https://en.bitcoin.it/wiki/List_of_address_prefixes
+        assertTrue(InvoiceUtil.isBitcoinAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")); //bech32, mainnet, lower case
+        assertTrue(InvoiceUtil.isBitcoinAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".toUpperCase())); //bech32, mainnet, upper case
+        assertTrue(InvoiceUtil.isBitcoinAddress("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx")); //bech32, mestnet, lower case
+        assertTrue(InvoiceUtil.isBitcoinAddress("bcrt1q6rhpng9evdsfnn833a4f4vej0asu6dk5srld6x")); //bech32, regtest, lower case
+        assertTrue(InvoiceUtil.isBitcoinAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem")); //base58, mainnet, P2PKH
+        assertTrue(InvoiceUtil.isBitcoinAddress("mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn")); //base58, testnet, P2PKH
+        assertTrue(InvoiceUtil.isBitcoinAddress("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX")); //base58, mainnet, P2SH
+        assertTrue(InvoiceUtil.isBitcoinAddress("2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc")); //base58, testnet, P2SH
+    }
+
+    @Test
+    public void givenInvalidBitcoinAddress_whenIsBitcoinAddress_ThenIsBitcoinAddressReturnFalse() {
+        assertFalse(InvoiceUtil.isBitcoinAddress("bc1Qw508d6qEjxtdg4y5r3zarvArY0c5xw7kv8f3T4")); //bech32, mixed case
+        assertFalse(InvoiceUtil.isBitcoinAddress("bc1qi508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")); //bech32, invalid character (i)
+        assertFalse(InvoiceUtil.isBitcoinAddress("b1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")); //bech32, invalid prefix/hrp
+        assertFalse(InvoiceUtil.isBitcoinAddress("1IVZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem")); //base58, invalid character (I)
+        assertFalse(InvoiceUtil.isBitcoinAddress("47VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem")); //base58, invalid prefix
+        assertFalse(InvoiceUtil.isBitcoinAddress("bc1test")); //valid address prefix, but random ending
+        assertFalse(InvoiceUtil.isBitcoinAddress("bitcoinFixesThis")); //arbitraryString
+    }
+    
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves address validation for On-Chain addresses and adds some unit tests for it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Until now the validation was only based on the prefix. This means for example "1testaddress" was seen as valid address and the send dialog would have been called when scanning this data.
Sending funds to that address would not have been possible though, as LND validates it correctly before sending and throws an error.
With this update Zap will throw an error immediately stating it is not a valid address.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.