### PR TITLE
Fixed a null error on "do not show again" warning messages

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/UserGuardian.java
+++ b/app/src/main/java/zapsolutions/zap/util/UserGuardian.java
@@ -270,7 +270,9 @@ public class UserGuardian {
             }
             dlg.show();
         } else {
-            mListener.onGuardianConfirmed();
+            if (mListener != null) {
+                mListener.onGuardianConfirmed();
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes an error, that occured on UserGuardian messages which have been flagged as "do not show again" and have no callback action.
One example is the new "old lnd" warning. Having this message flagged as "do not show again" and still not upgrading could lead to the wallet not loading.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Getting rid of bugs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regtest with LND 10.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.