### PR TITLE
Bip21 - lightning parameter support

### DIFF
--- a/app/src/main/java/zapsolutions/zap/GeneratedRequestActivity.java
+++ b/app/src/main/java/zapsolutions/zap/GeneratedRequestActivity.java
@@ -22,6 +22,7 @@ import net.glxn.qrgen.android.QRCode;
 
 import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.util.ClipBoardUtil;
+import zapsolutions.zap.util.InvoiceUtil;
 import zapsolutions.zap.util.MonetaryUtil;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.UriUtil;
@@ -84,17 +85,8 @@ public class GeneratedRequestActivity extends BaseAppCompatActivity implements W
 
 
             // Generate on-chain request data to encode
+            mDataToEncode = InvoiceUtil.generateBitcoinInvoice(mAddress, mAmount, mMemo, null);
 
-            mDataToEncode = UriUtil.generateBitcoinUri(mAddress);
-            mMemo = UrlEscapers.urlPathSegmentEscaper().escape(mMemo);
-
-            // Append amount and memo to the invoice
-            if (mAmount != null)
-                if (!(mAmount.isEmpty() || mAmount.equals("0")))
-                    mDataToEncode = appendParameter(mDataToEncode, "amount", mAmount);
-            if (mMemo != null)
-                if (!mMemo.isEmpty())
-                    mDataToEncode = appendParameter(mDataToEncode, "message", mMemo);
         } else {
             // Generate lightning request data to encode
             mDataToEncode = UriUtil.generateLightningUri(mLnInvoice);
@@ -191,13 +183,6 @@ public class GeneratedRequestActivity extends BaseAppCompatActivity implements W
             }
         });
 
-    }
-
-    private String appendParameter(String base, String name, String value) {
-        if (!base.contains("?"))
-            return base + "?" + name + "=" + value;
-        else
-            return base + "&" + name + "=" + value;
     }
 
     @Override

--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -581,6 +581,7 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
                         @Override
                         public void onError(String error, int duration) {
                             // If the added lightning parameter contains an invalid lightning invoice, we fall back to the onChain invoice.
+                            ZapLog.d(LOG_TAG, "Falling back to onChain Invoice: " + error);
                             SendBSDFragment sendBSDFragment = SendBSDFragment.createOnChainDialog(address, amount, message);
                             sendBSDFragment.show(getSupportFragmentManager(), "sendBottomSheetDialog");
                         }

--- a/app/src/main/java/zapsolutions/zap/ScanActivity.java
+++ b/app/src/main/java/zapsolutions/zap/ScanActivity.java
@@ -91,7 +91,7 @@ public class ScanActivity extends BaseScannerActivity {
             }
 
             @Override
-            public void onValidBitcoinInvoice(String address, long amount, String message) {
+            public void onValidBitcoinInvoice(String address, long amount, String message, String lightningInvoice) {
                 readableDataFound(data);
             }
 

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ScanNodePubKeyActivity.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ScanNodePubKeyActivity.java
@@ -158,7 +158,7 @@ public class ScanNodePubKeyActivity extends BaseScannerActivity implements Light
             }
 
             @Override
-            public void onValidBitcoinInvoice(String address, long amount, String message) {
+            public void onValidBitcoinInvoice(String address, long amount, String message, String lightningInvoice) {
                 showError(getResources().getString(R.string.error_lightning_uri_invalid), RefConstants.ERROR_DURATION_LONG);
             }
 

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -46,6 +46,7 @@ import com.github.lightningnetwork.lnd.lnrpc.SendRequest;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import zapsolutions.zap.HomeActivity;
 import zapsolutions.zap.R;
 import zapsolutions.zap.channelManagement.ManageChannelsActivity;
 import zapsolutions.zap.connection.lndConnection.LndConnection;
@@ -69,6 +70,7 @@ public class SendBSDFragment extends RxBSDFragment {
     private ImageView mIvBsdIcon;
     private ConstraintLayout mIconAnchor;
     private TextView mTvTitle;
+    private String mFallbackOnChainInvoice;
 
     private View mSendAmountView;
     private EditText mEtAmount;
@@ -84,6 +86,7 @@ public class SendBSDFragment extends RxBSDFragment {
     private View mProgressScreen;
     private View mFinishedScreen;
     private Button mOkButton;
+    private Button mFallbackButton;
     private ImageView mProgressFinishedIcon;
     private ImageView mIvProgressPaymentTypeIcon;
     private ImageView mIvFinishedPaymentTypeIcon;
@@ -109,11 +112,12 @@ public class SendBSDFragment extends RxBSDFragment {
     private float mLnFeePercentCalculated;
     private float mLnFeePercentSettingLimit;
 
-    public static SendBSDFragment createLightningDialog(PayReq paymentRequest, String invoice) {
+    public static SendBSDFragment createLightningDialog(PayReq paymentRequest, String invoice, String fallbackOnChainInvoice) {
         Intent intent = new Intent();
         intent.putExtra("onChain", false);
         intent.putExtra("lnPaymentRequest", paymentRequest.toByteArray());
         intent.putExtra("lnInvoice", invoice);
+        intent.putExtra("fallbackOnChainInvoice", fallbackOnChainInvoice);
         SendBSDFragment sendBottomSheetDialog = new SendBSDFragment();
         sendBottomSheetDialog.setArguments(intent.getExtras());
         return sendBottomSheetDialog;
@@ -150,6 +154,7 @@ public class SendBSDFragment extends RxBSDFragment {
 
                 mLnPaymentRequest = paymentRequest;
                 mLnInvoice = args.getString("lnInvoice");
+                mFallbackOnChainInvoice = args.getString("fallbackOnChainInvoice");
             } catch (InvalidProtocolBufferException e) {
                 throw new RuntimeException("Invalid payment request forwarded." + e.getMessage());
             }
@@ -183,6 +188,7 @@ public class SendBSDFragment extends RxBSDFragment {
         mProgressScreen = view.findViewById(R.id.paymentProgressLayout);
         mFinishedScreen = view.findViewById(R.id.paymentFinishedLayout);
         mOkButton = view.findViewById(R.id.okButton);
+        mFallbackButton = view.findViewById(R.id.fallbackButton);
         mProgressFinishedIcon = view.findViewById(R.id.progressFinishedIcon);
         mIvProgressPaymentTypeIcon = view.findViewById(R.id.progressPaymentTypeIcon);
         mIvFinishedPaymentTypeIcon = view.findViewById(R.id.finishedPaymentTypeIcon);
@@ -520,6 +526,14 @@ public class SendBSDFragment extends RxBSDFragment {
             }
         });
 
+        mFallbackButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ((HomeActivity) getActivity()).analyzeString(mFallbackOnChainInvoice);
+                dismiss();
+            }
+        });
+
         return view;
     }
 
@@ -638,7 +652,6 @@ public class SendBSDFragment extends RxBSDFragment {
         mBtnSend.setEnabled(false);
         mBtnManageChannels.setEnabled(false);
         mEtAmount.setEnabled(false);
-        mNumpad.setEnabled(false);
 
         // Animate out
 
@@ -790,6 +803,11 @@ public class SendBSDFragment extends RxBSDFragment {
 
         mFinishedScreen.startAnimation(animateIn);
 
+
+        if (!mOnChain) {
+            mFallbackButton.setEnabled(true);
+            mFallbackButton.setVisibility(View.VISIBLE);
+        }
         // Enable Ok button
         mOkButton.setEnabled(true);
     }

--- a/app/src/main/java/zapsolutions/zap/util/BitcoinStringAnalyzer.java
+++ b/app/src/main/java/zapsolutions/zap/util/BitcoinStringAnalyzer.java
@@ -128,8 +128,8 @@ public class BitcoinStringAnalyzer {
             }
 
             @Override
-            public void onValidBitcoinInvoice(String address, long amount, String message) {
-                listener.onValidBitcoinInvoice(address, amount, message);
+            public void onValidBitcoinInvoice(String address, long amount, String message, String lightningInvoice) {
+                listener.onValidBitcoinInvoice(address, amount, message, lightningInvoice);
             }
 
             @Override
@@ -149,7 +149,7 @@ public class BitcoinStringAnalyzer {
     public interface OnDataDecodedListener {
         void onValidLightningInvoice(PayReq paymentRequest, String invoice);
 
-        void onValidBitcoinInvoice(String address, long amount, String message);
+        void onValidBitcoinInvoice(String address, long amount, String message, String lightningInvoice);
 
         void onValidLnUrlWithdraw(LnUrlWithdrawResponse withdrawResponse);
 

--- a/app/src/main/java/zapsolutions/zap/util/ClipBoardUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/ClipBoardUtil.java
@@ -85,7 +85,7 @@ public class ClipBoardUtil {
             }
 
             @Override
-            public void onValidBitcoinInvoice(String address, long amount, String message) {
+            public void onValidBitcoinInvoice(String address, long amount, String message, String lightningInvoice) {
                 showProceedQuestion(R.string.clipboard_scan_payment, context, listener);
             }
 

--- a/app/src/main/java/zapsolutions/zap/util/MonetaryUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/MonetaryUtil.java
@@ -478,6 +478,27 @@ public class MonetaryUtil {
         }
     }
 
+    /**
+     * Converts the given satoshis to bitcoin currency.
+     *
+     * @param satoshiValue
+     * @return String without grouping and maximum fractions of 8 digits
+     */
+    public String convertSatoshiToBitcoin(String satoshiValue) {
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
+        DecimalFormat df = (DecimalFormat) nf;
+        df.setGroupingUsed(false);
+        df.setMaximumFractionDigits(8);
+
+        if (satoshiValue == null || satoshiValue.equals("")) {
+            return "0";
+        } else {
+                double value = Double.parseDouble(satoshiValue);
+                double result = (value / 1e8);
+                return df.format(result);
+        }
+    }
+
 
     /**
      * Checks if a numerical currency input is valid

--- a/app/src/main/res/layout/bsd_send.xml
+++ b/app/src/main/res/layout/bsd_send.xml
@@ -431,6 +431,25 @@
         </LinearLayout>
 
         <Button
+            android:id="@+id/fallbackButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginEnd="30dp"
+            android:layout_marginBottom="15dp"
+            android:background="@drawable/bg_clickable_item"
+            android:visibility="gone"
+            android:enabled="false"
+            android:text="@string/send_SendOnChainInstead"
+            android:textAllCaps="false"
+            android:textColor="@color/lightningOrange"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toTopOf="@id/okButton"
+            app:layout_constraintEnd_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <Button
             android:id="@+id/okButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/bsd_send.xml
+++ b/app/src/main/res/layout/bsd_send.xml
@@ -432,7 +432,7 @@
 
         <Button
             android:id="@+id/fallbackButton"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="30dp"
             android:layout_marginTop="15dp"
@@ -445,13 +445,13 @@
             android:textAllCaps="false"
             android:textColor="@color/lightningOrange"
             android:textSize="16sp"
-            app:layout_constraintBottom_toTopOf="@id/okButton"
-            app:layout_constraintEnd_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/okButton"
             app:layout_constraintStart_toStartOf="parent" />
 
         <Button
             android:id="@+id/okButton"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="30dp"
             android:layout_marginTop="15dp"
@@ -464,8 +464,8 @@
             android:textColor="@color/lightningOrange"
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/fallbackButton" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="send_sendPayment">Send payment</string>
     <string name="send_success">Payment\nsuccessful</string>
     <string name="send_fail">Payment\nfailed</string>
+    <string name="send_SendOnChainInstead">Send On-Chain</string>
 
 
     <string name="receive_generateRequest">Generate Request</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support for classical bip21 style bitcoin invoices which include a lightning invoice by adding the "lightning=lnbc..." parameter.
If the appended lightning invoice is invalid or the user does not have enough channel balance to pay it, when scanned, the on-chain dialog will automatically shown.
Otherwhise, the lightning dialog is automatically displayed.
If the lightning payment fails, the user is given the possibility to fall back to on-chain payment.

The design does not look perfect yet. The whole bottom sheets need a refactoring, but that is something for a different PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make Zap more versatile. Fix issue #269.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.