### PR TITLE
Fix incorrectly shown fallback option on failed lightning payments

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -804,7 +804,7 @@ public class SendBSDFragment extends RxBSDFragment {
         mFinishedScreen.startAnimation(animateIn);
 
 
-        if (!mOnChain) {
+        if (!mOnChain && mFallbackOnChainInvoice != null) {
             mFallbackButton.setEnabled(true);
             mFallbackButton.setVisibility(View.VISIBLE);
         }


### PR DESCRIPTION
Fixes an error introduced in the last PR.
We of course want to only show the fallback if a fallback is actually present...