### PR TITLE
Add route hints for private channels + option

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/ReceiveBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/ReceiveBSDFragment.java
@@ -477,6 +477,7 @@ public class ReceiveBSDFragment extends RxBSDFragment {
                         .setValue(value)
                         .setMemo(mEtMemo.getText().toString())
                         .setExpiry(Long.parseLong(PrefsUtil.getPrefs().getString("lightning_expiry", "86400"))) // in seconds
+                        .setPrivate(PrefsUtil.getPrefs().getBoolean("includePrivateChannelHints", true))
                         .build();
 
                 getCompositeDisposable().add(LndConnection.getInstance().getLightningService().addInvoice(asyncInvoiceRequest)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
 
     <string name="settings_lnRequestExpiryTitle">Lightning Request Expiry</string>
     <string name="settings_lnFeeLimitTitle">Lightning Payment Fee Limit</string>
+    <string name="settings_lnPrivateChannelHints">Include route hints for private channels in invoices</string>
 
 
     <string name="error">Error</string>

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -63,6 +63,12 @@
             android:title="@string/settings_lnFeeLimitTitle"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="includePrivateChannelHints"
+            android:title="@string/settings_lnPrivateChannelHints"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds routing hints for private channels to invoices by default.
It also introduces an option in the advanced settings, that allows to turn this off.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address issue #274
Allow Zap to be used on devices constraint to private channels only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regtest

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.