### PR TITLE
Remove local/remote setup choice

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
@@ -288,6 +288,7 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), SetupActivity.class);
                 intent.putExtra(RefConstants.SETUP_MODE, SetupActivity.FULL_SETUP);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/zapsolutions/zap/setup/SetupActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/SetupActivity.java
@@ -1,5 +1,6 @@
 package zapsolutions.zap.setup;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.fragment.app.Fragment;
@@ -60,7 +61,11 @@ public class SetupActivity extends BaseAppCompatActivity implements PinActivityI
     }
 
     private void showConnectChoice() {
-        changeFragment(new ConnectFragment());
+        // The choice is skipped right now. Instead we immediately go to the scan activity
+        //changeFragment(new ConnectFragment());
+
+        Intent intent = new Intent(SetupActivity.this, ConnectRemoteNodeActivity.class);
+        startActivity(intent);
     }
 
     private void changeFragment(Fragment fragment) {

--- a/app/src/main/java/zapsolutions/zap/walletManagement/ManageWalletsActivity.java
+++ b/app/src/main/java/zapsolutions/zap/walletManagement/ManageWalletsActivity.java
@@ -55,6 +55,7 @@ public class ManageWalletsActivity extends BaseAppCompatActivity {
             public void onClick(View view) {
                 // Add a new wallet
                 Intent intent = new Intent(ManageWalletsActivity.this, SetupActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                 startActivity(intent);
             }
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the setup choice screen that actually never has been a choice. There was only one option: "remote"
This does not mean, that local lnd will not come, but when it comes, everything will look different anyway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce unnecessary steps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.