### PR TITLE
Prevent unnecessary clipboard popups

### DIFF
--- a/app/src/main/java/zapsolutions/zap/ScanActivity.java
+++ b/app/src/main/java/zapsolutions/zap/ScanActivity.java
@@ -46,7 +46,7 @@ public class ScanActivity extends BaseScannerActivity {
         super.onButtonPasteClick();
 
         try {
-            readData(ClipBoardUtil.getPrimaryContent(getApplicationContext()));
+            readData(ClipBoardUtil.getPrimaryContent(getApplicationContext(), true));
         } catch (NullPointerException e) {
             showError(getResources().getString(R.string.error_emptyClipboardPayment), RefConstants.ERROR_DURATION_SHORT);
         }

--- a/app/src/main/java/zapsolutions/zap/channelManagement/ScanNodePubKeyActivity.java
+++ b/app/src/main/java/zapsolutions/zap/channelManagement/ScanNodePubKeyActivity.java
@@ -129,7 +129,7 @@ public class ScanNodePubKeyActivity extends BaseScannerActivity implements Light
         super.onButtonPasteClick();
 
         try {
-            String clipboardContent = ClipBoardUtil.getPrimaryContent(getApplicationContext());
+            String clipboardContent = ClipBoardUtil.getPrimaryContent(getApplicationContext(),true);
             processUserData(clipboardContent);
         } catch (NullPointerException e) {
             showError(getResources().getString(R.string.error_emptyClipboardConnect), RefConstants.ERROR_DURATION_SHORT);

--- a/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/setup/ConnectRemoteNodeActivity.java
@@ -55,7 +55,7 @@ public class ConnectRemoteNodeActivity extends BaseScannerActivity {
         String clipboardContent = "";
         boolean isClipboardContentValid = false;
         try {
-            clipboardContent = ClipBoardUtil.getPrimaryContent(getApplicationContext());
+            clipboardContent = ClipBoardUtil.getPrimaryContent(getApplicationContext(), true);
             isClipboardContentValid = true;
         } catch (NullPointerException e) {
             showError(getResources().getString(R.string.error_emptyClipboardConnect), RefConstants.ERROR_DURATION_SHORT);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR resolves the following situation:
If no wallet exists yet and a new wallet is added by pasting the connect string in the connection activity, right after the wallet is created a popup appears stating: "Connection data was found, do you want to use it now?"
This should not be the case, as it was just used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Get rid of unnecessary popups

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.