### PR TITLE
androidx.security library implementation  -> Min SDK increased to 23 (Android 6.0)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 30
     defaultConfig {
         applicationId "zapsolutions.zap"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 30
         versionCode 26
         versionName "0.3.8-beta"
@@ -201,6 +201,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.biometric:biometric:1.0.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
     implementation 'com.google.android.material:material:1.2.1'
 
     // Libraries for tests

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/Cryptography.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/Cryptography.java
@@ -43,6 +43,8 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.x500.X500Principal;
 
+// ToDo: Deprecated! Remove this class soon. It is just used for backwards compatibility right now.
+
 /*
 MIT License: https://opensource.org/licenses/MIT
 Copyright 2017 Diederik Hattingh

--- a/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsManager.java
+++ b/app/src/main/java/zapsolutions/zap/connection/manageWalletConfigs/WalletConfigsManager.java
@@ -7,23 +7,12 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import java.io.IOException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.UnrecoverableEntryException;
-import java.security.cert.CertificateException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-
-import zapsolutions.zap.baseClasses.App;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.ZapLog;
 
@@ -42,12 +31,10 @@ public class WalletConfigsManager {
 
     private WalletConfigsManager() {
 
-        String encrypted = PrefsUtil.getPrefs().getString(PrefsUtil.WALLET_CONFIGS, "");
-
         String decrypted = null;
         try {
-            decrypted = new Cryptography(App.getAppContext()).decryptData(encrypted);
-        } catch (Exception e) {
+            decrypted = PrefsUtil.getEncryptedPrefs().getString(PrefsUtil.WALLET_CONFIGS, "");
+        } catch (GeneralSecurityException | IOException e) {
             e.printStackTrace();
         }
 
@@ -315,24 +302,14 @@ public class WalletConfigsManager {
      * Saves the current state of wallet configs encrypted to default shared preferences.
      * Always use this after you have changed anything on the configurations.
      *
+     * @throws GeneralSecurityException
      * @throws IOException
-     * @throws CertificateException
-     * @throws NoSuchAlgorithmException
-     * @throws InvalidKeyException
-     * @throws UnrecoverableEntryException
-     * @throws InvalidAlgorithmParameterException
-     * @throws NoSuchPaddingException
-     * @throws NoSuchProviderException
-     * @throws BadPaddingException
-     * @throws KeyStoreException
-     * @throws IllegalBlockSizeException
      */
-    public void apply() throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeyException, UnrecoverableEntryException, InvalidAlgorithmParameterException, NoSuchPaddingException, NoSuchProviderException, BadPaddingException, KeyStoreException, IllegalBlockSizeException {
+    public void apply() throws GeneralSecurityException, IOException {
         // Convert JSON object to string
         String jsonString = new Gson().toJson(mWalletConfigsJson);
 
         // Save the new WalletConfigurations in encrypted prefs
-        String encrypted = new Cryptography(App.getAppContext()).encryptData(jsonString);
-        PrefsUtil.edit().putString(PrefsUtil.WALLET_CONFIGS, encrypted).commit();
+        PrefsUtil.editEncryptedPrefs().putString(PrefsUtil.WALLET_CONFIGS, jsonString).commit();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SettingsFragment.java
@@ -33,6 +33,7 @@ import zapsolutions.zap.connection.manageWalletConfigs.Cryptography;
 import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.pin.PinSetupActivity;
 import zapsolutions.zap.util.AppUtil;
+import zapsolutions.zap.util.KeystoreUtil;
 import zapsolutions.zap.util.MonetaryUtil;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.RefConstants;
@@ -162,6 +163,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 PrefsUtil.edit().clear().commit();
                 try {
                     new Cryptography(App.getAppContext()).removeKeys();
+                    new KeystoreUtil().removePinActiveKey();
                 } catch (KeyStoreException e) {
                     e.printStackTrace();
                 } catch (CertificateException e) {

--- a/app/src/main/java/zapsolutions/zap/pin/PinEntryActivity.java
+++ b/app/src/main/java/zapsolutions/zap/pin/PinEntryActivity.java
@@ -22,6 +22,8 @@ import androidx.annotation.NonNull;
 import androidx.biometric.BiometricPrompt;
 import androidx.core.content.ContextCompat;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -316,7 +318,12 @@ public class PinEntryActivity extends BaseAppCompatActivity {
         // Check if PIN was correct
         String userEnteredPin = mUserInput.toString();
         String hashedInput = UtilFunctions.pinHash(userEnteredPin);
-        boolean correct = PrefsUtil.getPrefs().getString(PrefsUtil.PIN_HASH, "").equals(hashedInput);
+        boolean correct = false;
+        try {
+            correct = PrefsUtil.getEncryptedPrefs().getString(PrefsUtil.PIN_HASH, "").equals(hashedInput);
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
         if (correct) {
             TimeOutUtil.getInstance().restartTimer();
 

--- a/app/src/main/java/zapsolutions/zap/pin/PinSetupActivity.java
+++ b/app/src/main/java/zapsolutions/zap/pin/PinSetupActivity.java
@@ -7,10 +7,14 @@ import android.widget.Toast;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 import zapsolutions.zap.HomeActivity;
 import zapsolutions.zap.R;
 import zapsolutions.zap.baseClasses.BaseAppCompatActivity;
 import zapsolutions.zap.connection.manageWalletConfigs.Cryptography;
+import zapsolutions.zap.util.KeystoreUtil;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.RefConstants;
 import zapsolutions.zap.util.TimeOutUtil;
@@ -59,16 +63,24 @@ public class PinSetupActivity extends BaseAppCompatActivity implements PinActivi
 
     public void pinConfirmed(String value) {
 
-        // save pin hash in preferences
+        // save pin hash in encrypted prefs
+        try {
+            PrefsUtil.editEncryptedPrefs()
+                    .putString(PrefsUtil.PIN_HASH, UtilFunctions.pinHash(value))
+                    .commit();
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
+        }
+
+        // save pin length in preferences
         PrefsUtil.edit()
-                .putString(PrefsUtil.PIN_HASH, UtilFunctions.pinHash(value))
                 .putInt(PrefsUtil.PIN_LENGTH, value.length())
                 .commit();
 
 
         if (mSetupMode == ADD_PIN) {
             try {
-                new Cryptography(this).addPinActiveKey();
+                new KeystoreUtil().addPinActiveKey();
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/zapsolutions/zap/util/KeystoreUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/KeystoreUtil.java
@@ -1,0 +1,58 @@
+package zapsolutions.zap.util;
+
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.cert.CertificateException;
+
+import javax.crypto.KeyGenerator;
+
+public class KeystoreUtil {
+    private static final String KEY_PIN_ACTIVE = "PinActiveKey";
+    private static final String ANDROID_KEY_STORE_NAME = "AndroidKeyStore";
+    private final static Object s_keyInitLock = new Object();
+
+    public void addPinActiveKey() throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException, InvalidAlgorithmParameterException, NoSuchProviderException {
+        KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_NAME);
+        keyStore.load(null);
+
+        if (!keyStore.containsAlias(KEY_PIN_ACTIVE)) {
+            generateKey(KEY_PIN_ACTIVE);
+        }
+    }
+
+    public void removePinActiveKey() throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        synchronized (s_keyInitLock) {
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_NAME);
+            keyStore.load(null);
+            keyStore.deleteEntry(KEY_PIN_ACTIVE);
+        }
+    }
+
+    public boolean isPinActive() throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_NAME);
+        keyStore.load(null);
+        return keyStore.containsAlias(KEY_PIN_ACTIVE);
+    }
+
+    protected void generateKey(String keyAlias) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+        synchronized (s_keyInitLock) {
+            KeyGenerator keyGenerator;
+            keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE_NAME);
+            keyGenerator.init(
+                    new KeyGenParameterSpec.Builder(keyAlias,
+                            KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                            .setRandomizedEncryptionRequired(false)
+                            .build());
+            keyGenerator.generateKey();
+        }
+    }
+}

--- a/app/src/main/java/zapsolutions/zap/util/PinScreenUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PinScreenUtil.java
@@ -6,7 +6,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 
 import zapsolutions.zap.R;
-import zapsolutions.zap.connection.manageWalletConfigs.Cryptography;
 import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.pin.PinEntryActivity;
 
@@ -24,14 +23,15 @@ public class PinScreenUtil {
                 // Check if pin is active according to key store
                 boolean isPinActive = false;
                 try {
-                    isPinActive = new Cryptography(activity).isPinActive();
+                    isPinActive = new KeystoreUtil().isPinActive();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
 
                 // Only allow access if pin is not active in key store!
                 if (isPinActive) {
-                    // According to the key store, the pin is still active. This happens if the pin got deleted from the prefs without also removing the keystore entry.
+                    // According to the key store, the pin is still active. This happens if the pin got deleted from the prefs file without also removing the keystore entry.
+                    // Basically this would be the case if the PIN hash was removed in a different way than from the apps settings menu. (For example with a file explorer on a rooted device)
                     new AlertDialog.Builder(activity)
                             .setMessage(R.string.error_pin_deactivation_attempt)
                             .setCancelable(false)

--- a/app/src/main/java/zapsolutions/zap/util/RefConstants.java
+++ b/app/src/main/java/zapsolutions/zap/util/RefConstants.java
@@ -11,10 +11,11 @@ public class RefConstants {
 
     History:
     16: Biometrics and new Cryptography using Android Keystore
-    17: Removed deviceID usage
-    18: Wallet name based WalletConfigs -> UUID based WalletConfigs
+    17: Removed deviceID usage (0.2.5-alpha)
+    18: Wallet name based WalletConfigs -> UUID based WalletConfigs (0.3.0-beta)
+    19: Androidx.security implementation (0.3.9-beta)
     */
-    public static final int CURRENT_SETTINGS_VERSION = 18;
+    public static final int CURRENT_SETTINGS_VERSION = 19;
 
     // If any changes are done here, CURRENT_SETTINGS_VERSION has to be updated.
     public static final int NUM_HASH_ITERATIONS = 5000;

--- a/app/src/main/java/zapsolutions/zap/util/UtilFunctions.java
+++ b/app/src/main/java/zapsolutions/zap/util/UtilFunctions.java
@@ -1,6 +1,8 @@
 package zapsolutions.zap.util;
 
+import java.io.IOException;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -8,9 +10,6 @@ import java.security.spec.InvalidKeySpecException;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
-
-import zapsolutions.zap.baseClasses.App;
-import zapsolutions.zap.connection.manageWalletConfigs.Cryptography;
 
 public class UtilFunctions {
     private final static char[] hexArray = "0123456789abcdef".toCharArray();
@@ -46,12 +45,16 @@ public class UtilFunctions {
 
     public static String getZapsalt() {
 
-        if (!PrefsUtil.getPrefs().contains(PrefsUtil.RANDOM_SOURCE)) {
-            createRandomSource();
+        try {
+            if (!PrefsUtil.getEncryptedPrefs().contains(PrefsUtil.RANDOM_SOURCE)) {
+                createRandomSource();
+            }
+        } catch (GeneralSecurityException | IOException e) {
+            e.printStackTrace();
         }
         String salt = "";
         try {
-            String decrypted = new Cryptography(App.getAppContext()).decryptData(PrefsUtil.getPrefs().getString(PrefsUtil.RANDOM_SOURCE, ""));
+            String decrypted = PrefsUtil.getEncryptedPrefs().getString(PrefsUtil.RANDOM_SOURCE, "");
             salt = "zap" + decrypted;
         } catch (Exception e) {
             e.printStackTrace();
@@ -64,8 +67,7 @@ public class UtilFunctions {
         try {
             SecureRandom random = new SecureRandom();
             int randomNumber = random.nextInt();
-            String encrypted = new Cryptography(App.getAppContext()).encryptData(String.valueOf(randomNumber));
-            PrefsUtil.edit().putString(PrefsUtil.RANDOM_SOURCE, encrypted).commit();
+            PrefsUtil.editEncryptedPrefs().putString(PrefsUtil.RANDOM_SOURCE, String.valueOf(randomNumber)).commit();
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces the cryptography class with googles official androidx.security library.
It also provides automated migration of the encrypted data to keep already existing connections and the pin working.
The PIN Hash is now also encrypted making it harder to extract and then crack with something like hashcat.
The old cryptography class does still exist, as it is needed for migrating previously encrypted data. It will be removed in a later release.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This shift makes the security part of Zap a lot easier to audit and will hopefully also make it easier for new developers to join the project.
The official library is also well maintained which ensures that Zap will receive critical security updates in the future. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.