### PR TITLE
Multi path payments

### DIFF
--- a/app/src/main/java/zapsolutions/zap/LandingActivity.java
+++ b/app/src/main/java/zapsolutions/zap/LandingActivity.java
@@ -53,6 +53,8 @@ public class LandingActivity extends BaseAppCompatActivity {
             }
         }
 
+        // Make sure the old lnd message is always shown:
+        PrefsUtil.editPrefs().putBoolean("guardianOldLndVersion", false).apply();
 
         // support for clearing shared preferences, on breaking changes
         if (PrefsUtil.getPrefs().contains(PrefsUtil.SETTINGS_VERSION)) {

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -489,7 +489,7 @@ public class SendBSDFragment extends ZapBSDFragment {
         } else {
             // Fallback to multi path payment as no route was found
 
-            SendPaymentRequest mppSendRequest = PaymentUtil.prepareMPPPayment(mLnPaymentRequest);
+            SendPaymentRequest mppSendRequest = PaymentUtil.prepareMPPPayment(mLnPaymentRequest, mLnInvoice);
 
             PaymentUtil.sendMppPayment(mppSendRequest, getCompositeDisposable(), new PaymentUtil.OnMPPPaymentResult() {
                 @Override

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -27,6 +27,7 @@ import androidx.transition.TransitionManager;
 import com.github.lightningnetwork.lnd.lnrpc.EstimateFeeRequest;
 import com.github.lightningnetwork.lnd.lnrpc.Failure;
 import com.github.lightningnetwork.lnd.lnrpc.PayReq;
+import com.github.lightningnetwork.lnd.lnrpc.Payment;
 import com.github.lightningnetwork.lnd.lnrpc.PaymentFailureReason;
 import com.github.lightningnetwork.lnd.lnrpc.Route;
 import com.github.lightningnetwork.lnd.lnrpc.SendCoinsRequest;
@@ -493,7 +494,7 @@ public class SendBSDFragment extends ZapBSDFragment {
 
             PaymentUtil.sendMppPayment(mppSendRequest, getCompositeDisposable(), new PaymentUtil.OnMPPPaymentResult() {
                 @Override
-                public void onSuccess() {
+                public void onSuccess(Payment payment) {
                     mHandler.postDelayed(() -> switchToSuccessScreen(), 300);
                 }
 
@@ -683,7 +684,7 @@ public class SendBSDFragment extends ZapBSDFragment {
                 String feePercentageString = " (" + String.format("%.1f", mCalculatedFeePercent * 100) + "%)";
                 long fee = PaymentUtil.calculateAbsoluteFeeLimit(paymentAmountSat);
                 String feeString = MonetaryUtil.getInstance().getPrimaryDisplayAmount(fee) + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
-                feeString = "up to " + feeString + feePercentageString;
+                feeString = R.string.maximum_abbreviation + " " + feeString + feePercentageString;
                 setCalculatedFeeAmount(feeString);
             }
 

--- a/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/SendBSDFragment.java
@@ -25,12 +25,12 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.transition.TransitionManager;
 
 import com.github.lightningnetwork.lnd.lnrpc.EstimateFeeRequest;
-import com.github.lightningnetwork.lnd.lnrpc.FeeLimit;
+import com.github.lightningnetwork.lnd.lnrpc.Failure;
 import com.github.lightningnetwork.lnd.lnrpc.PayReq;
-import com.github.lightningnetwork.lnd.lnrpc.QueryRoutesRequest;
+import com.github.lightningnetwork.lnd.lnrpc.PaymentFailureReason;
 import com.github.lightningnetwork.lnd.lnrpc.Route;
 import com.github.lightningnetwork.lnd.lnrpc.SendCoinsRequest;
-import com.github.lightningnetwork.lnd.lnrpc.SendRequest;
+import com.github.lightningnetwork.lnd.routerrpc.SendPaymentRequest;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import zapsolutions.zap.HomeActivity;
@@ -39,11 +39,12 @@ import zapsolutions.zap.connection.lndConnection.LndConnection;
 import zapsolutions.zap.connection.manageWalletConfigs.WalletConfigsManager;
 import zapsolutions.zap.customView.BSDProgressView;
 import zapsolutions.zap.customView.BSDResultView;
+import zapsolutions.zap.customView.BSDScrollableMainView;
 import zapsolutions.zap.customView.LightningFeeView;
 import zapsolutions.zap.customView.NumpadView;
 import zapsolutions.zap.customView.OnChainFeeView;
-import zapsolutions.zap.customView.BSDScrollableMainView;
 import zapsolutions.zap.util.MonetaryUtil;
+import zapsolutions.zap.util.PaymentUtil;
 import zapsolutions.zap.util.PrefsUtil;
 import zapsolutions.zap.util.RefConstants;
 import zapsolutions.zap.util.Wallet;
@@ -78,8 +79,11 @@ public class SendBSDFragment extends ZapBSDFragment {
     private long mFixedAmount;
     private Handler mHandler;
     private boolean mAmountValid = true;
-    private float mLnFeePercentCalculated;
-    private float mLnFeePercentSettingLimit;
+    private boolean mSendButtonEnabled_input;
+    private boolean mSendButtonEnabled_feeCalculate;
+    private Route mRoute;
+    long mCalculatedFee;
+    double mCalculatedFeePercent;
 
     public static SendBSDFragment createLightningDialog(PayReq paymentRequest, String invoice, String fallbackOnChainInvoice) {
         Intent intent = new Intent();
@@ -127,8 +131,6 @@ public class SendBSDFragment extends ZapBSDFragment {
         }
 
         View view = inflater.inflate(R.layout.bsd_send, container);
-
-        setLightningFeeLimit();
 
         mBSDScrollableMainView = view.findViewById(R.id.scrollableBottomSheet);
         mProgressScreen = view.findViewById(R.id.paymentProgressLayout);
@@ -194,17 +196,15 @@ public class SendBSDFragment extends ZapBSDFragment {
                         mEtAmount.setTextColor(getResources().getColor(R.color.superRed));
                         String maxAmount = getResources().getString(R.string.max_amount) + " " + MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(maxSendable);
                         Toast.makeText(getActivity(), maxAmount, Toast.LENGTH_SHORT).show();
-                        mBtnSend.setEnabled(false);
-                        mBtnSend.setTextColor(getResources().getColor(R.color.gray));
+                        mSendButtonEnabled_input = false;
                     } else {
                         mEtAmount.setTextColor(getResources().getColor(R.color.white));
-                        mBtnSend.setEnabled(true);
-                        mBtnSend.setTextColor(getResources().getColor(R.color.lightningOrange));
+                        mSendButtonEnabled_input = true;
                     }
                     if (currentValue == 0 && mFixedAmount == 0L) {
-                        mBtnSend.setEnabled(false);
-                        mBtnSend.setTextColor(getResources().getColor(R.color.gray));
+                        mSendButtonEnabled_input = false;
                     }
+                    updateSendButtonState();
                 }
             }
 
@@ -266,19 +266,14 @@ public class SendBSDFragment extends ZapBSDFragment {
             } else {
                 // No specific amount was requested. Let User input an amount.
                 mNumpad.setVisibility(View.VISIBLE);
-                mBtnSend.setEnabled(false);
-                mBtnSend.setTextColor(getResources().getColor(R.color.gray));
+                mSendButtonEnabled_input = false;
+                updateSendButtonState();
 
                 mHandler.postDelayed(() -> {
                     // We have to call this delayed, as otherwise it will still bring up the softKeyboard
                     mEtAmount.requestFocus();
                 }, 200);
 
-            }
-
-
-            if (mMemo != null) {
-                mEtMemo.setText(mMemo);
             }
 
             // Action when clicked on "Send payment"
@@ -342,8 +337,8 @@ public class SendBSDFragment extends ZapBSDFragment {
             mProgressScreen.setProgressTypeIcon(R.drawable.ic_nav_wallet_black_24dp);
             mBSDScrollableMainView.setTitle(R.string.send_lightningPayment);
 
-            if (mLnPaymentRequest.getDescription() == null) {
-                mMemoView.setVisibility(View.VISIBLE);
+            if (mLnPaymentRequest.getDescription() == null || mLnPaymentRequest.getDescription().isEmpty()) {
+                mMemoView.setVisibility(View.GONE);
             } else {
                 mMemoView.setVisibility(View.VISIBLE);
                 mEtMemo.setText(mLnPaymentRequest.getDescription());
@@ -358,8 +353,8 @@ public class SendBSDFragment extends ZapBSDFragment {
             } else {
                 // No specific amount was requested. Let User input an amount.
                 mNumpad.setVisibility(View.VISIBLE);
-                mBtnSend.setEnabled(false);
-                mBtnSend.setTextColor(getResources().getColor(R.color.gray));
+                mSendButtonEnabled_input = false;
+                updateSendButtonState();
 
                 mHandler.postDelayed(() -> {
                     // We have to call this delayed, as otherwise it will still bring up the softKeyboard
@@ -373,56 +368,30 @@ public class SendBSDFragment extends ZapBSDFragment {
                 @Override
                 public void onClick(View v) {
 
-                    // send lightning payment
                     if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
-                        SendRequest.Builder srb = SendRequest.newBuilder();
 
-                        if (mLnPaymentRequest.getNumSatoshis() <= RefConstants.LN_PAYMENT_FEE_THRESHOLD) {
-                            // ignore setting if below threshold
-                            if (mLnFeePercentCalculated >= 1f) {
-                                // fee higher than payment
-                                int feeSats = (int) (mLnPaymentRequest.getNumSatoshis() * mLnFeePercentCalculated);
-                                String feeLimitString = getString(R.string.fee_limit_exceeded_payment, feeSats, mLnPaymentRequest.getNumSatoshis());
-                                showFeeAlertDialog(srb, feeLimitString);
+                        // sanity check for fees
+                        if (mCalculatedFee != -1) {
+                            if (mCalculatedFeePercent >= 1f) {
+                                // fee higher or equal to payment amount
+                                String feeLimitString = getString(R.string.fee_limit_exceeded_payment, mCalculatedFee, mLnPaymentRequest.getNumSatoshis());
+                                showFeeAlertDialog(feeLimitString);
                                 return;
-                            } else {
-                                // could not calculate fee, or fee is below payment
-                                // set sanity fee, no one pays more fees than the value of payment
-                                srb.setFeeLimit(FeeLimit.newBuilder()
-                                        .setPercent(100)
-                                        .build());
                             }
-                        } else {
-                            // check against fee setting
-                            if (mLnFeePercentSettingLimit != 1) {
-                                if (mLnFeePercentCalculated > mLnFeePercentSettingLimit) {
-                                    // fee is higher than settings, ask user
-                                    String feeLimitString = getString(R.string.fee_limit_exceeded, mLnFeePercentCalculated * 100, mLnFeePercentSettingLimit * 100);
-                                    showFeeAlertDialog(srb, feeLimitString);
-                                    return;
-                                } else {
-                                    // could not calculate fee, or fee is below limit
-                                    // set limit from settings and try payment
-                                    srb.setFeeLimit(FeeLimit.newBuilder()
-                                            .setPercent((long) (mLnFeePercentSettingLimit * 100)))
-                                            .build();
-                                }
-                            } else {
-                                // fee higher than payment
-                                if (mLnFeePercentCalculated >= 1f) {
-                                    int feeSats = (int) (mLnPaymentRequest.getNumSatoshis() * mLnFeePercentCalculated);
-                                    String feeLimitString = getString(R.string.fee_limit_exceeded_payment, feeSats, mLnPaymentRequest.getNumSatoshis());
-                                    showFeeAlertDialog(srb, feeLimitString);
+                            if (mLnPaymentRequest.getNumSatoshis() > RefConstants.LN_PAYMENT_FEE_THRESHOLD)
+                                if (mCalculatedFeePercent > PaymentUtil.getRelativeSettingsFeeLimit()) {
+                                    // fee higher or equal to payment amount
+                                    String feeLimitString = getString(R.string.fee_limit_exceeded, mCalculatedFeePercent * 100, PaymentUtil.getRelativeSettingsFeeLimit() * 100);
+                                    showFeeAlertDialog(feeLimitString);
                                     return;
                                 }
-                            }
                         }
-
-                        sendPayment(srb);
+                        sendLightningPayment();
                     } else {
                         // Demo Mode
                         Toast.makeText(getActivity(), R.string.demo_setupWalletFirst, Toast.LENGTH_SHORT).show();
                     }
+
                 }
             });
         }
@@ -466,12 +435,12 @@ public class SendBSDFragment extends ZapBSDFragment {
         super.onDestroyView();
     }
 
-    private void showFeeAlertDialog(SendRequest.Builder paymentRequestBuilder, String message) {
+    private void showFeeAlertDialog(String message) {
         AlertDialog.Builder adb = new AlertDialog.Builder(getContext())
                 .setTitle(R.string.fee_limit_title)
                 .setMessage(message)
                 .setCancelable(true)
-                .setPositiveButton(R.string.yes, (dialog, whichButton) -> sendPayment(paymentRequestBuilder))
+                .setPositiveButton(R.string.yes, (dialog, whichButton) -> sendLightningPayment())
                 .setNegativeButton(R.string.no, (dialog, whichButton) -> {
                 });
         Dialog dlg = adb.create();
@@ -482,60 +451,81 @@ public class SendBSDFragment extends ZapBSDFragment {
         dlg.show();
     }
 
-    private void setLightningFeeLimit() {
-        String lightning_feeLimit = PrefsUtil.getPrefs().getString("lightning_feeLimit", "3%");
-        String feePercent = lightning_feeLimit.replace("%", "");
-
-        if (feePercent.equals(getString(R.string.none))) {
-            mLnFeePercentSettingLimit = 1;
-        } else {
-            mLnFeePercentSettingLimit = Integer.parseInt(feePercent) / 100f;
-        }
-    }
-
-    private void sendPayment(SendRequest.Builder paymentRequestBuilder) {
+    private void sendLightningPayment() {
         switchToSendProgressScreen();
 
-        ZapLog.d(LOG_TAG, "Trying to send lightning payment...");
-
-        paymentRequestBuilder.setPaymentRequest(mLnInvoice);
-
         if (mLnPaymentRequest.getNumSatoshis() == 0) {
-            paymentRequestBuilder.setAmt(Long.parseLong(MonetaryUtil.getInstance().convertPrimaryToSatoshi(mEtAmount.getText().toString())));
             mResultView.setDetailsText(MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(Long.parseLong(MonetaryUtil.getInstance().convertPrimaryToSatoshi(mEtAmount.getText().toString()))));
         } else {
             mResultView.setDetailsText(MonetaryUtil.getInstance().getPrimaryDisplayAmountAndUnit(mLnPaymentRequest.getNumSatoshis()));
         }
 
-        SendRequest sendRequest = paymentRequestBuilder.build();
+        if (mRoute != null) {
+            PaymentUtil.sendToRoute(mLnPaymentRequest.getPaymentHash(), mRoute, getCompositeDisposable(), new PaymentUtil.OnSendToRouteResult() {
+                @Override
+                public void onSuccess() {
+                    mHandler.postDelayed(() -> switchToSuccessScreen(), 300);
+                }
 
-        getCompositeDisposable().add(LndConnection.getInstance().getLightningService().sendPaymentSync(sendRequest)
-                .subscribe(sendResponse -> {
-                    // updated the history, so it is shown the next time the user views it
-                    Wallet.getInstance().updateLightningPaymentHistory();
-
-                    ZapLog.v(LOG_TAG, sendResponse.toString());
-
-                    // show success animation
-                    mHandler.postDelayed(() -> {
-                        if (sendResponse.getPaymentError().equals("")) {
-                            switchToSuccessScreen();
-                        } else {
-                            String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ": ";
-                            String error = errorPrefix + sendResponse.getPaymentError();
-                            switchToFailedScreen(error);
-                        }
-
-                    }, 500);
-                }, throwable -> {
-                    ZapLog.e(LOG_TAG, "Exception in send payment task.");
-                    ZapLog.e(LOG_TAG, throwable.getMessage());
-
+                @Override
+                public void onError(String error, Failure reason, int duration) {
                     String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ":";
-                    String errorMessage = throwable.getMessage().replace("UNKNOWN:", errorPrefix);
+                    String errorMessage;
+                    if (reason != null) {
+                        switch (reason.getCode()) {
+                            case INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS:
+                                errorMessage = errorPrefix + "\n\n" + getResources().getString(R.string.error_payment_invalid_details);
+                                break;
+                            default:
+                                errorMessage = errorPrefix + "\n\n" + error;
+                                break;
+                        }
+                    } else {
+                        errorMessage = error.replace("UNKNOWN:", errorPrefix);
+                    }
                     mHandler.postDelayed(() -> switchToFailedScreen(errorMessage), 300);
+                }
+            });
+        } else {
+            // Fallback to multi path payment as no route was found
 
-                }));
+            SendPaymentRequest mppSendRequest = PaymentUtil.prepareMPPPayment(mLnPaymentRequest);
+
+            PaymentUtil.sendMppPayment(mppSendRequest, getCompositeDisposable(), new PaymentUtil.OnMPPPaymentResult() {
+                @Override
+                public void onSuccess() {
+                    mHandler.postDelayed(() -> switchToSuccessScreen(), 300);
+                }
+
+                @Override
+                public void onError(String error, PaymentFailureReason reason, int duration) {
+                    String errorPrefix = getResources().getString(R.string.error).toUpperCase() + ":";
+                    String errorMessage;
+                    if (reason != null) {
+                        switch (reason) {
+                            case FAILURE_REASON_TIMEOUT:
+                                errorMessage = errorPrefix + "\n\n" + getResources().getString(R.string.error_payment_timeout);
+                                break;
+                            case FAILURE_REASON_NO_ROUTE:
+                                errorMessage = errorPrefix + "\n\n" + getResources().getString(R.string.error_payment_no_route);
+                                break;
+                            case FAILURE_REASON_INSUFFICIENT_BALANCE:
+                                errorMessage = errorPrefix + "\n\n" + getResources().getString(R.string.error_payment_insufficient_balance);
+                                break;
+                            case FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
+                                errorMessage = errorPrefix + "\n\n" + getResources().getString(R.string.error_payment_invalid_details);
+                                break;
+                            default:
+                                errorMessage = errorPrefix + "\n\n" + error;
+                                break;
+                        }
+                    } else {
+                        errorMessage = error.replace("UNKNOWN:", errorPrefix);
+                    }
+                    mHandler.postDelayed(() -> switchToFailedScreen(errorMessage), 300);
+                }
+            });
+        }
     }
 
     private void switchToSendProgressScreen() {
@@ -592,9 +582,11 @@ public class SendBSDFragment extends ZapBSDFragment {
                 } catch (NumberFormatException e) {
 
                 }
-                queryRoutes(mLnPaymentRequest.getDestination(), sendAmount);
+                SendPaymentRequest probeRequest = PaymentUtil.preparePaymentProbe(mLnPaymentRequest.getDestination(), sendAmount);
+                sendPaymentProbe(probeRequest);
             } else {
-                queryRoutes(mLnPaymentRequest.getDestination(), mLnPaymentRequest.getNumSatoshis());
+                SendPaymentRequest probeRequest = PaymentUtil.preparePaymentProbe(mLnPaymentRequest);
+                sendPaymentProbe(probeRequest);
             }
         }
     }
@@ -603,6 +595,8 @@ public class SendBSDFragment extends ZapBSDFragment {
      * Show progress while calculating fee
      */
     private void setCalculatingFee() {
+        mSendButtonEnabled_feeCalculate = false;
+        updateSendButtonState();
         if (mOnChain) {
             // On chain fee calculation is very fast, no need for progress indication
         } else {
@@ -614,6 +608,8 @@ public class SendBSDFragment extends ZapBSDFragment {
      * Show the calculated fee
      */
     private void setCalculatedFeeAmount(String amount) {
+        mSendButtonEnabled_feeCalculate = true;
+        updateSendButtonState();
         if (mOnChain) {
             mOnChainFeeView.onFeeSuccess(amount);
         } else {
@@ -625,10 +621,23 @@ public class SendBSDFragment extends ZapBSDFragment {
      * Show fee calculation failure
      */
     private void setFeeFailure() {
+        mSendButtonEnabled_feeCalculate = true;
+        updateSendButtonState();
         if (mOnChain) {
             mOnChainFeeView.onFeeFailure();
         } else {
+            mRoute = null;
             mLightningFeeView.onFeeFailure();
+        }
+    }
+
+    private void updateSendButtonState() {
+        if (mSendButtonEnabled_feeCalculate && mSendButtonEnabled_input) {
+            mBtnSend.setEnabled(true);
+            mBtnSend.setTextColor(getResources().getColor(R.color.lightningOrange));
+        } else {
+            mBtnSend.setEnabled(false);
+            mBtnSend.setTextColor(getResources().getColor(R.color.gray));
         }
     }
 
@@ -651,41 +660,39 @@ public class SendBSDFragment extends ZapBSDFragment {
                         }));
     }
 
-    /**
-     * Query Routes. This is used to determine the expected fees for a lightning payment.
-     */
-    private void queryRoutes(String pubKey, long amount) {
-        QueryRoutesRequest asyncQueryRoutesRequest = QueryRoutesRequest.newBuilder()
-                .setPubKey(pubKey)
-                .setAmt(amount)
-                .setUseMissionControl(true)
-                .build();
 
-        getCompositeDisposable().add(LndConnection.getInstance().getLightningService().queryRoutes(asyncQueryRoutesRequest)
-                .subscribe(queryRoutesResponse -> {
-                    if (queryRoutesResponse.getRoutesCount() == 0) {
-                        ZapLog.d(LOG_TAG, "No route found.");
-                        setFeeFailure();
-                    } else {
-                        Route route = queryRoutesResponse.getRoutes(0);
+    private void sendPaymentProbe(SendPaymentRequest probeRequest) {
+        PaymentUtil.sendPaymentProbe(probeRequest, getCompositeDisposable(), new PaymentUtil.OnPaymentProbeResult() {
 
-                        // We have to add one sat as the value gets truncated.
-                        // Example: If the fee was actually 700 Msat it would result in 0 sat (= 0 Msat)
-                        //          and could lead to "no route" error when applied as fee limit.
-                        long calculatedFeeSats = (route.getTotalFeesMsat() / 1000) + 1;
+            @Override
+            public void onSuccess(long fee, Route route, long paymentAmountSat) {
+                mRoute = route;
+                mCalculatedFee = fee;
+                mCalculatedFeePercent = (fee / (double) paymentAmountSat);
+                String feePercentageString = " (" + String.format("%.1f", mCalculatedFeePercent * 100) + "%)";
+                String feeString = MonetaryUtil.getInstance().getPrimaryDisplayAmount(fee) + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
+                feeString = feeString + feePercentageString;
+                setCalculatedFeeAmount(feeString);
+            }
 
-                        mLnFeePercentCalculated = ((float) calculatedFeeSats / amount);
-                        String feePercentageString = " (" + String.format("%.1f", mLnFeePercentCalculated * 100) + "%)";
+            @Override
+            public void onNoRoute(long paymentAmountSat) {
+                // Display fee according to max UserSetting
+                mCalculatedFee = PaymentUtil.calculateAbsoluteFeeLimit(paymentAmountSat);
+                mCalculatedFeePercent = PaymentUtil.calculateRelativeFeeLimit(paymentAmountSat);
+                String feePercentageString = " (" + String.format("%.1f", mCalculatedFeePercent * 100) + "%)";
+                long fee = PaymentUtil.calculateAbsoluteFeeLimit(paymentAmountSat);
+                String feeString = MonetaryUtil.getInstance().getPrimaryDisplayAmount(fee) + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
+                feeString = "up to " + feeString + feePercentageString;
+                setCalculatedFeeAmount(feeString);
+            }
 
-                        String feeString = MonetaryUtil.getInstance().getPrimaryDisplayAmount(calculatedFeeSats) + " " + MonetaryUtil.getInstance().getPrimaryDisplayUnit();
-                        feeString = feeString + feePercentageString;
-                        setCalculatedFeeAmount(feeString);
-                    }
-                }, throwable -> {
-                    ZapLog.w(LOG_TAG, "Exception in query routes request task.");
-                    ZapLog.w(LOG_TAG, throwable.getMessage());
-                    setFeeFailure();
-                }));
+            @Override
+            public void onError(String error, int duration) {
+                mCalculatedFee = -1;
+                mCalculatedFeePercent = -1;
+                setFeeFailure();
+            }
+        });
     }
-
 }

--- a/app/src/main/java/zapsolutions/zap/util/PaymentUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PaymentUtil.java
@@ -189,7 +189,7 @@ public class PaymentUtil {
      * For payments of over 100 sat we apply the user settings, for payments lower, we use the square root of the amount to send.
      *
      * @param amountSatToSend Amount that should be send with the transaction
-     * @return maixmum number of sats in fee
+     * @return maximum number of sats in fee
      */
     public static long calculateAbsoluteFeeLimit(long amountSatToSend) {
         long absFee;

--- a/app/src/main/java/zapsolutions/zap/util/PaymentUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PaymentUtil.java
@@ -1,0 +1,240 @@
+package zapsolutions.zap.util;
+
+import com.github.lightningnetwork.lnd.lnrpc.Failure;
+import com.github.lightningnetwork.lnd.lnrpc.PayReq;
+import com.github.lightningnetwork.lnd.lnrpc.PaymentFailureReason;
+import com.github.lightningnetwork.lnd.lnrpc.Route;
+import com.github.lightningnetwork.lnd.routerrpc.SendPaymentRequest;
+import com.github.lightningnetwork.lnd.routerrpc.SendToRouteRequest;
+import com.google.common.io.BaseEncoding;
+import com.google.protobuf.ByteString;
+
+import java.security.SecureRandom;
+
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import zapsolutions.zap.R;
+import zapsolutions.zap.baseClasses.App;
+import zapsolutions.zap.connection.lndConnection.LndConnection;
+
+public class PaymentUtil {
+
+    private static final String LOG_TAG = PaymentUtil.class.getName();
+
+
+    public static SendPaymentRequest preparePaymentProbe(PayReq paymentRequest) {
+        return preparePaymentProbe(paymentRequest.getDestination(), paymentRequest.getNumSatoshis());
+    }
+
+    public static SendPaymentRequest preparePaymentProbe(String destination, long amountSat) {
+        // The paymentHash will be replaced with a random hash. This way we can create a fake payment.
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+
+        long feeLimit = calculateAbsoluteFeeLimit(amountSat);
+
+        return SendPaymentRequest.newBuilder()
+                .setDest(byteStringFromHex(destination))
+                .setAmt(amountSat)
+                .setFeeLimitSat(feeLimit)
+                .setPaymentHash(ByteString.copyFrom(bytes))
+                .setNoInflightUpdates(true)
+                .setTimeoutSeconds(RefConstants.TIMEOUT_MEDIUM * RefConstants.TOR_TIMEOUT_MULTIPLIER)
+                .setMaxParts(1) // We are looking for a direct path. Probing using MPP isn’t really possible at the moment.
+                .build();
+    }
+
+    /**
+     * With a payment probe we test if a route can be found. (no multi path payments)
+     * <p>
+     * A payment probe is basically a normal transaction with a faked payment hash.
+     * If a route is found, then the exact fee and route can be extracted from that payment probe.
+     * This way we can show the user the exact amount of fee necessary and pay later by using SendToRouteV2.
+     * If a route can’t be found, we present the user “up to xxx sats” where xxx is a fee limit that is configurable via user settings.
+     * In this case we fall back to a multi path payment as a last try to get the payment through.
+     *
+     * @param probeSendRequest    A request created with the preparePaymentProbe function
+     * @param compositeDisposable CompositeDisposable the async action gets executed on
+     * @param result              OnPaymentProbeResult interface
+     */
+    public static void sendPaymentProbe(SendPaymentRequest probeSendRequest, CompositeDisposable compositeDisposable, OnPaymentProbeResult result) {
+        if (probeSendRequest == null)
+            result.onError("Probe send request was null", RefConstants.ERROR_DURATION_MEDIUM);
+
+        ZapLog.d(LOG_TAG, "Sending payment probe...");
+
+        compositeDisposable.add(LndConnection.getInstance().getRouterService().sendPaymentV2(probeSendRequest)
+                .subscribe(payment -> {
+                    ZapLog.v(LOG_TAG, payment.toString());
+
+                    switch (payment.getFailureReason()) {
+                        case FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
+                            Route route = payment.getHtlcs(0).getRoute();
+                            long feeSats = 0;
+                            if (route.getTotalFeesMsat() % 1000 == 0) {
+                                feeSats = route.getTotalFeesMsat() / 1000;
+                            } else {
+                                feeSats = (route.getTotalFeesMsat() / 1000) + 1;
+                            }
+                            result.onSuccess(feeSats, route, probeSendRequest.getAmt());
+                            break;
+                        case FAILURE_REASON_NO_ROUTE:
+                            result.onNoRoute(probeSendRequest.getAmt());
+                            break;
+                        default:
+                            result.onError(payment.getFailureReason().toString(), RefConstants.ERROR_DURATION_MEDIUM);
+                    }
+
+                }, throwable -> {
+                    ZapLog.e(LOG_TAG, "Exception while executing payment probe.");
+                    ZapLog.e(LOG_TAG, throwable.getMessage());
+
+                    result.onError(throwable.getMessage(), RefConstants.ERROR_DURATION_MEDIUM);
+                }));
+    }
+
+    /**
+     * Used to send a payment through a predefined route.
+     * To determine a route use the sendPaymentProbe function.
+     *
+     * @param paymentHash         The payment hash for the payment
+     * @param route               The route to take
+     * @param compositeDisposable CompositeDisposable the async action gets executed on
+     * @param result              OnLightningPaymentResult interface
+     */
+    public static void sendToRoute(String paymentHash, Route route, CompositeDisposable compositeDisposable, OnSendToRouteResult result) {
+        SendToRouteRequest sendToRouteRequest = SendToRouteRequest.newBuilder()
+                .setPaymentHash(byteStringFromHex(paymentHash))
+                .setRoute(route)
+                .build();
+
+        ZapLog.d(LOG_TAG, "Trying to send lightning over specific route...");
+
+        compositeDisposable.add(LndConnection.getInstance().getRouterService().sendToRouteV2(sendToRouteRequest)
+                .subscribe(htlcAttempt -> {
+                    ZapLog.v(LOG_TAG, htlcAttempt.toString());
+
+                    switch (htlcAttempt.getStatus()) {
+                        case SUCCEEDED:
+                            // updated the history, so it is shown the next time the user views it
+                            Wallet.getInstance().updateLightningPaymentHistory();
+                            result.onSuccess();
+                            break;
+                        case FAILED:
+                            result.onError(htlcAttempt.getFailure().getCode().toString(), htlcAttempt.getFailure(), RefConstants.ERROR_DURATION_MEDIUM);
+                            break;
+                    }
+                }, throwable -> {
+                    ZapLog.e(LOG_TAG, "Exception while executing SendToRoute.");
+                    ZapLog.e(LOG_TAG, throwable.getMessage());
+
+                    result.onError(throwable.getMessage(), null, RefConstants.ERROR_DURATION_MEDIUM);
+                }));
+    }
+
+    public static SendPaymentRequest prepareMPPPayment(PayReq paymentRequest) {
+        return prepareMPPPayment(paymentRequest.getDestination(), paymentRequest.getPaymentHash(), paymentRequest.getNumSatoshis());
+    }
+
+    public static SendPaymentRequest prepareMPPPayment(String destination, String paymentHash, long amountSat) {
+        long feeLimit = calculateAbsoluteFeeLimit(amountSat);
+        return SendPaymentRequest.newBuilder()
+                .setDest(byteStringFromHex(destination))
+                .setAmt(amountSat)
+                .setFeeLimitSat(feeLimit)
+                .setPaymentHash(byteStringFromHex(paymentHash))
+                .setTimeoutSeconds(RefConstants.TIMEOUT_MEDIUM * RefConstants.TOR_TIMEOUT_MULTIPLIER)
+                .setMaxParts(RefConstants.LN_MAX_PARTS)
+                .build();
+    }
+
+    /**
+     * Used to send a lightning payment with multi paths enabled.
+     *
+     * @param sendPaymentRequest  A request created with the prepareMPPPayment function
+     * @param compositeDisposable CompositeDisposable the async action gets executed on
+     * @param result              OnLightningPaymentResult interface
+     */
+    public static void sendMppPayment(SendPaymentRequest sendPaymentRequest, CompositeDisposable compositeDisposable, OnMPPPaymentResult result) {
+        if (sendPaymentRequest == null)
+            result.onError("SendPaymentRequest was null", null, RefConstants.ERROR_DURATION_MEDIUM);
+
+        ZapLog.d(LOG_TAG, "Trying to send mpp lightning payment with " + sendPaymentRequest.getFeeLimitSat() + " sat fee limit...");
+
+        compositeDisposable.add(LndConnection.getInstance().getRouterService().sendPaymentV2(sendPaymentRequest)
+                .subscribe(payment -> {
+                    ZapLog.v(LOG_TAG, payment.toString());
+
+                    switch (payment.getStatus()) {
+                        case SUCCEEDED:
+                            // updated the history, so it is shown the next time the user views it
+                            Wallet.getInstance().updateLightningPaymentHistory();
+                            result.onSuccess();
+                            break;
+                        case FAILED:
+                            result.onError(payment.getFailureReason().toString(), payment.getFailureReason(), RefConstants.ERROR_DURATION_MEDIUM);
+                            break;
+                    }
+                }, throwable -> {
+                    ZapLog.e(LOG_TAG, "Exception in mpp lightning payment task.");
+                    result.onError(throwable.getMessage(), null, RefConstants.ERROR_DURATION_MEDIUM);
+                }));
+    }
+
+    // ByteString values when using for example "paymentRequest.getDescriptionBytes()" can for some reason not directly be used as they are double in length
+    private static ByteString byteStringFromHex(String hexString) {
+        byte[] hexBytes = BaseEncoding.base16().decode(hexString.toUpperCase());
+        return ByteString.copyFrom(hexBytes);
+    }
+
+    /**
+     * We always allow a fee of at least 3 sats, to ensure also small payments have a chance.
+     * For payments of over 100 sat we apply the user settings, for payments lower, we use the square root of the amount to send.
+     *
+     * @param amountSatToSend
+     * @return
+     */
+    public static long calculateAbsoluteFeeLimit(long amountSatToSend) {
+        long absFee;
+        if (amountSatToSend <= RefConstants.LN_PAYMENT_FEE_THRESHOLD) {
+            absFee = (long) (Math.sqrt(amountSatToSend));
+        } else {
+            absFee = (long) (getRelativeSettingsFeeLimit() * amountSatToSend);
+        }
+        return Math.max(absFee, 3L);
+    }
+
+    public static float getRelativeSettingsFeeLimit() {
+        String lightning_feeLimit = PrefsUtil.getPrefs().getString("lightning_feeLimit", "3%");
+        String feePercent = lightning_feeLimit.replace("%", "");
+        float feeMultiplier = 1f;
+        if (!feePercent.equals(App.getAppContext().getResources().getString(R.string.none))) {
+            feeMultiplier = Integer.parseInt(feePercent) / 100f;
+        }
+        return feeMultiplier;
+    }
+
+    public static float calculateRelativeFeeLimit(long amountSatToSend) {
+        return (float) calculateAbsoluteFeeLimit(amountSatToSend) / (float) amountSatToSend;
+    }
+
+    public interface OnPaymentProbeResult {
+        void onSuccess(long fee, Route route, long paymentAmountSat);
+
+        void onNoRoute(long paymentAmountSat);
+
+        void onError(String error, int duration);
+    }
+
+    public interface OnSendToRouteResult {
+        void onSuccess();
+
+        void onError(String error, Failure reason, int duration);
+    }
+
+    public interface OnMPPPaymentResult {
+        void onSuccess();
+
+        void onError(String error, PaymentFailureReason reason, int duration);
+    }
+}

--- a/app/src/main/java/zapsolutions/zap/util/PaymentUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PaymentUtil.java
@@ -2,6 +2,7 @@ package zapsolutions.zap.util;
 
 import com.github.lightningnetwork.lnd.lnrpc.Failure;
 import com.github.lightningnetwork.lnd.lnrpc.PayReq;
+import com.github.lightningnetwork.lnd.lnrpc.Payment;
 import com.github.lightningnetwork.lnd.lnrpc.PaymentFailureReason;
 import com.github.lightningnetwork.lnd.lnrpc.Route;
 import com.github.lightningnetwork.lnd.routerrpc.SendPaymentRequest;
@@ -165,7 +166,7 @@ public class PaymentUtil {
                         case SUCCEEDED:
                             // updated the history, so it is shown the next time the user views it
                             Wallet.getInstance().updateLightningPaymentHistory();
-                            result.onSuccess();
+                            result.onSuccess(payment);
                             break;
                         case FAILED:
                             result.onError(payment.getFailureReason().toString(), payment.getFailureReason(), RefConstants.ERROR_DURATION_MEDIUM);
@@ -229,7 +230,7 @@ public class PaymentUtil {
     }
 
     public interface OnMPPPaymentResult {
-        void onSuccess();
+        void onSuccess(Payment payment);
 
         void onError(String error, PaymentFailureReason reason, int duration);
     }

--- a/app/src/main/java/zapsolutions/zap/util/RefConstants.java
+++ b/app/src/main/java/zapsolutions/zap/util/RefConstants.java
@@ -58,6 +58,9 @@ public class RefConstants {
     If the payment amount is above this threshold, the user setting will be considered. */
     public static final int LN_PAYMENT_FEE_THRESHOLD = 100;
 
+    // Max number of paths to use for multi path payments (mpp)
+    public static final int LN_MAX_PARTS = 10;
+
     // URLS
     public static final String URL_HELP = "https://docs.zaphq.io/docs-android-getting-started";
     public static final String URL_PRIVACY = "https://zaphq.io/privacy";

--- a/app/src/main/java/zapsolutions/zap/util/UserGuardian.java
+++ b/app/src/main/java/zapsolutions/zap/util/UserGuardian.java
@@ -203,7 +203,7 @@ public class UserGuardian {
      */
     public void securityOldLndVersion(String versionName) {
         mCurrentDialogName = DIALOG_OLD_LND_VERSION;
-        AlertDialog.Builder adb = createDontShowAgainDialog(true);
+        AlertDialog.Builder adb = createDialog(true);
         String message = mContext.getResources().getString(R.string.guardian_oldLndVersion_remote, versionName);
         adb.setMessage(message);
         showGuardianDialog(adb);
@@ -225,7 +225,7 @@ public class UserGuardian {
      * except the message.
      * This helps keeping the dialog functions organized and simple.
      *
-     * @param hasCancelOption wether it has a cancle option or not
+     * @param hasCancelOption whether it has a cancel option or not
      * @return returns a preconfigured AlertDialog.Builder which can be further configured later
      */
     private AlertDialog.Builder createDontShowAgainDialog(Boolean hasCancelOption) {
@@ -242,6 +242,32 @@ public class UserGuardian {
                 PrefsUtil.editPrefs().putBoolean(mCurrentDialogName, false).apply();
             }
 
+            if (mListener != null) {
+                // Execute interface callback on "OK"
+                mListener.onGuardianConfirmed();
+            }
+        });
+        if (hasCancelOption) {
+            adb.setNegativeButton(R.string.cancel, (dialog, which) -> {
+            });
+        }
+        return adb;
+    }
+
+    /**
+     * Create a dialog that is already set up
+     * except the message.
+     * This helps keeping the dialog functions organized and simple.
+     *
+     * @param hasCancelOption whether it has a cancel option or not
+     * @return returns a preconfigured AlertDialog.Builder which can be further configured later
+     */
+    private AlertDialog.Builder createDialog(Boolean hasCancelOption) {
+        AlertDialog.Builder adb = new AlertDialog.Builder(mContext);
+        LayoutInflater adbInflater = LayoutInflater.from(mContext);
+        View titleView = adbInflater.inflate(R.layout.guardian_title, null);
+        adb.setCustomTitle(titleView);
+        adb.setPositiveButton(R.string.ok, (dialog, which) -> {
             if (mListener != null) {
                 // Execute interface callback on "OK"
                 mListener.onGuardianConfirmed();

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -1231,7 +1231,7 @@ public class Wallet {
                 for (Channel c : mOpenChannelsList) {
                     if (c.getActive()) {
                         if (c.getRemoteBalance() > tempMax) {
-                            tempMax = c.getRemoteBalance();
+                            tempMax = Math.max(c.getRemoteBalance() - c.getRemoteConstraints().getChanReserveSat(), 0);
                         }
                     }
                 }
@@ -1243,7 +1243,7 @@ public class Wallet {
             if (mOpenChannelsList != null) {
                 for (Channel c : mOpenChannelsList) {
                     if (c.getActive()) {
-                        tempMax = tempMax + c.getRemoteBalance();
+                        tempMax = tempMax + Math.max(c.getRemoteBalance() - c.getRemoteConstraints().getChanReserveSat(), 0);
                     }
                 }
             }
@@ -1272,7 +1272,7 @@ public class Wallet {
                 for (Channel c : mOpenChannelsList) {
                     if (c.getActive()) {
                         if (c.getLocalBalance() > tempMax) {
-                            tempMax = c.getLocalBalance();
+                            tempMax = Math.max(c.getLocalBalance() - c.getLocalConstraints().getChanReserveSat(), 0);
                         }
                     }
                 }
@@ -1284,7 +1284,7 @@ public class Wallet {
             if (mOpenChannelsList != null) {
                 for (Channel c : mOpenChannelsList) {
                     if (c.getActive()) {
-                        tempMax = tempMax + c.getLocalBalance();
+                        tempMax = tempMax + Math.max(c.getLocalBalance() - c.getLocalConstraints().getChanReserveSat(), 0);
                     }
                 }
             }

--- a/app/src/main/res/layout/bsd_lnurl_pay.xml
+++ b/app/src/main/res/layout/bsd_lnurl_pay.xml
@@ -57,6 +57,46 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:srcCompat="@color/gray" />
 
+                <TextView
+                    android:id="@+id/payeeSourceLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@color/transparent"
+                    android:maxLength="50"
+                    android:paddingTop="5dp"
+                    android:paddingBottom="9dp"
+                    android:text="@string/payee"
+                    android:textAlignment="viewStart"
+                    android:textSize="20sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/line" />
+
+                <TextView
+                    android:id="@+id/sendPayee"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:background="@color/transparent"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:paddingStart="15dp"
+                    android:paddingTop="9dp"
+                    android:paddingBottom="9dp"
+                    android:textAlignment="viewEnd"
+                    android:textSize="16sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/payeeSourceLabel"
+                    app:layout_constraintTop_toBottomOf="@id/line"
+                    tools:text="lnurl.bigsun.xyz" />
+
+                <ImageView
+                    android:id="@+id/line2"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/payeeSourceLabel"
+                    app:srcCompat="@color/gray" />
+
                 <!-- Dummy item to prevent EditText from receiving focus -->
                 <LinearLayout
                     android:layout_width="0px"
@@ -78,7 +118,7 @@
                     android:textSize="20sp"
                     app:layout_constraintBottom_toBottomOf="@id/unitLayout"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toBottomOf="@id/line2" />
 
                 <EditText
                     android:id="@+id/sendAmount"
@@ -94,7 +134,7 @@
                     android:textSize="20sp"
                     app:layout_constraintEnd_toStartOf="@+id/unitLayout"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toBottomOf="@id/line2" />
 
                 <LinearLayout
                     android:id="@+id/unitLayout"
@@ -105,7 +145,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="1.0"
                     app:layout_constraintStart_toEndOf="@+id/sendAmount"
-                    app:layout_constraintTop_toTopOf="parent">
+                    app:layout_constraintTop_toBottomOf="@id/line2">
 
                     <zapsolutions.zap.customView.NonClippingTextView
                         android:id="@+id/unit"
@@ -127,8 +167,9 @@
                         app:tint="@color/lightningOrange" />
                 </LinearLayout>
 
+
                 <ImageView
-                    android:id="@+id/line2"
+                    android:id="@+id/line3"
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -136,45 +177,6 @@
                     app:layout_constraintTop_toBottomOf="@id/unitLayout"
                     app:srcCompat="@color/gray" />
 
-                <TextView
-                    android:id="@+id/payeeSourceLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:background="@color/transparent"
-                    android:maxLength="50"
-                    android:paddingTop="5dp"
-                    android:paddingBottom="9dp"
-                    android:text="@string/payee"
-                    android:textAlignment="viewStart"
-                    android:textSize="20sp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/line2" />
-
-                <TextView
-                    android:id="@+id/sendPayee"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:background="@color/transparent"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:paddingStart="15dp"
-                    android:paddingTop="9dp"
-                    android:paddingBottom="9dp"
-                    android:textAlignment="viewEnd"
-                    android:textSize="16sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/payeeSourceLabel"
-                    app:layout_constraintTop_toBottomOf="@id/line2"
-                    tools:text="lnurl.bigsun.xyz" />
-
-                <ImageView
-                    android:id="@+id/line3"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    app:layout_constraintTop_toBottomOf="@id/payeeSourceLabel"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:srcCompat="@color/gray" />
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/sendDescriptionTopLayout"
@@ -203,7 +205,6 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
-
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="open">Open</string>
     <string name="search">Search</string>
     <string name="confirmations">Confirmations</string>
+    <string name="maximum_abbreviation">max</string>
 
     <string name="activity_receive">Receive</string>
     <string name="activity_send">Pay</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,6 +304,10 @@
     <string name="error_pin_deactivation_attempt">It looks like someone tried to deactivate your PIN. The App will close now.\nYou can reinstall the app and use the recovery process to regain access to your funds.</string>
     <string name="error_empty_wallet_name">An empty name is not allowed.</string>
     <string name="error_invalid_bitcoin_request">Invalid bitcoin request.</string>
+    <string name="error_payment_invalid_details">The payment details did not match the details specified by the invoice you are trying to pay.</string>
+    <string name="error_payment_timeout">Timeout. No route could be found in the specified time.</string>
+    <string name="error_payment_no_route">No route could be found for the desired payment. Opening new lightning channels might solve the problem.</string>
+    <string name="error_payment_insufficient_balance">Your balance is insufficient to fulfill the payment.</string>
 
     <plurals name="duration_minute">
         <item quantity="one">%d Minute</item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Finally the PR to support Multi Path Payments! This PR does not only enable MPP, it also refactors the complete payment flow.
Instead of query routes, a payment probe is send. If the probe is successful, we take the exact same route for the actual payment. If it fails, due to no route found, we fall back to MPP as a last hope to get the payment through.
In this case we cannot determine the fee in advance and display the max from the settings as possible fee. 
The payment stuff is now moved to a PaymentUtil to make it more modular.
One further change is, that the warning that you use an old LND version (below 0.11) can no longer be marked as do not show again, payments do no longer work on older versions and people should update anyway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address issue #289 
Multi Path Payments (MPP) remove a big liquidity constraint in the lightning network, as payments are no longer limited to the maximum local balance of a single channel. This increases the success of a transaction going through.
Receiving MPP has been available for a while now, but  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Regtest, my S9

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.