### PR TITLE
Fix preview for bottom sheet dialogs

### DIFF
--- a/app/src/main/res/layout/bsd_base_scrollable.xml
+++ b/app/src/main/res/layout/bsd_base_scrollable.xml
@@ -52,8 +52,8 @@
         android:maxLength="25"
         android:paddingTop="10dp"
         android:paddingBottom="10dp"
-        android:textSize="22sp"
         android:textAlignment="center"
+        android:textSize="22sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/titleIcon"
@@ -80,7 +80,6 @@
         android:paddingBottom="10dp"
         android:scrollbars="vertical"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_max="200dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title">
 


### PR DESCRIPTION
Small fix that prevents the bottom sheet dialogs from being cut off in the preview in Android Studio.