### PR TITLE
Fix crash when opening identity if the wallet is not fully synced

### DIFF
--- a/app/src/main/java/zapsolutions/zap/HomeActivity.java
+++ b/app/src/main/java/zapsolutions/zap/HomeActivity.java
@@ -143,8 +143,12 @@ public class HomeActivity extends BaseAppCompatActivity implements LifecycleObse
             public void onSingleClick(View v) {
                 if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
                     if (Wallet.getInstance().isConnectedToLND()) {
-                        Intent intent = new Intent(HomeActivity.this, IdentityActivity.class);
-                        startActivity(intent);
+                        if (Wallet.getInstance().getNodeUris().length > 0) {
+                            Intent intent = new Intent(HomeActivity.this, IdentityActivity.class);
+                            startActivity(intent);
+                        } else {
+                            Toast.makeText(HomeActivity.this, R.string.error_wallet_not_yet_ready, Toast.LENGTH_LONG).show();
+                        }
                     }
                 } else {
                     Toast.makeText(HomeActivity.this, R.string.demo_setupWalletFirstAvatar, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/zapsolutions/zap/customView/UserAvatarView.java
+++ b/app/src/main/java/zapsolutions/zap/customView/UserAvatarView.java
@@ -136,7 +136,7 @@ public class UserAvatarView extends ConstraintLayout {
         mCurrentUriId = 0;
         mIvUserAvatar.setOnClickListener(null);
         mIvQRCode.setOnClickListener(null);
-        mIvUserAvatar.setImageResource(R.drawable.ic_person_24);
+        mIvUserAvatar.setImageResource(R.drawable.unknown_avatar);
     }
 
     private void showQRCode() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,6 +320,7 @@
     <string name="error_payment_insufficient_balance">The amount to pay is bigger than what you can send over lightning with your current open channels.</string>
     <string name="error_payment_keysend_not_enabled_on_remote">Please make sure the recipient has enabled the keysend feature.</string>
     <string name="error_only_payment_data_allowed">Only payment data is allowed here.</string>
+    <string name="error_wallet_not_yet_ready">Your wallet is not fully synced yet. Please try again later.</string>
 
     <plurals name="duration_minute">
         <item quantity="one">%d Minute</item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a crash and ensures the correct "unknown" image is shown in the drawer during wallet switching.