### PR TITLE
Fix multiple history list issues that caused inconsistent display of data

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/ChooseNodeActionBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/ChooseNodeActionBSDFragment.java
@@ -54,7 +54,7 @@ public class ChooseNodeActionBSDFragment extends ZapBSDFragment {
         bsdScrollableMainView.setTitle(R.string.choose_action);
 
         if (WalletConfigsManager.getInstance().hasAnyConfigs()) {
-            Wallet.getInstance().fetchNodeInfoFromLND(mNodeUri.getPubKey());
+            Wallet.getInstance().fetchNodeInfoFromLND(mNodeUri.getPubKey(), false);
         }
 
         // Check if this node is already a contact.

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/HistoryItemAdapter.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/HistoryItemAdapter.java
@@ -14,7 +14,6 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import zapsolutions.zap.R;
 import zapsolutions.zap.transactionHistory.listItems.DateItem;
 import zapsolutions.zap.transactionHistory.listItems.DateLineViewHolder;
-import zapsolutions.zap.transactionHistory.listItems.HistoryItemViewHolder;
 import zapsolutions.zap.transactionHistory.listItems.HistoryListItem;
 import zapsolutions.zap.transactionHistory.listItems.LnInvoiceItem;
 import zapsolutions.zap.transactionHistory.listItems.LnInvoiceViewHolder;
@@ -128,22 +127,6 @@ public class HistoryItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
             default:
                 throw new IllegalStateException("Unknown history list item type: " + type);
         }
-    }
-
-    @Override
-    public void onViewAttachedToWindow(@NonNull RecyclerView.ViewHolder holder) {
-        if (holder instanceof HistoryItemViewHolder) {
-            ((HistoryItemViewHolder) holder).registerPrefListener();
-        }
-        super.onViewAttachedToWindow(holder);
-    }
-
-    @Override
-    public void onViewDetachedFromWindow(@NonNull RecyclerView.ViewHolder holder) {
-        if (holder instanceof HistoryItemViewHolder) {
-            ((HistoryItemViewHolder) holder).unregisterPrefListener();
-        }
-        super.onViewDetachedFromWindow(holder);
     }
 
     public void replaceAll(List<HistoryListItem> items) {

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/HistoryItemViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/HistoryItemViewHolder.java
@@ -1,14 +1,11 @@
 package zapsolutions.zap.transactionHistory.listItems;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.view.View;
 
 import androidx.recyclerview.widget.RecyclerView;
 
-import zapsolutions.zap.util.PrefsUtil;
-
-public abstract class HistoryItemViewHolder extends RecyclerView.ViewHolder implements SharedPreferences.OnSharedPreferenceChangeListener {
+public abstract class HistoryItemViewHolder extends RecyclerView.ViewHolder {
     protected Context mContext;
 
     public HistoryItemViewHolder(View v) {
@@ -16,17 +13,7 @@ public abstract class HistoryItemViewHolder extends RecyclerView.ViewHolder impl
         mContext = v.getContext();
     }
 
+    public void refreshViewHolder() {
 
-    @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-
-    }
-
-    public void unregisterPrefListener() {
-        PrefsUtil.getPrefs().unregisterOnSharedPreferenceChangeListener(this);
-    }
-
-    public void registerPrefListener() {
-        PrefsUtil.getPrefs().registerOnSharedPreferenceChangeListener(this);
     }
 }

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnInvoiceViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnInvoiceViewHolder.java
@@ -1,6 +1,5 @@
 package zapsolutions.zap.transactionHistory.listItems;
 
-import android.content.SharedPreferences;
 import android.view.View;
 
 import zapsolutions.zap.R;
@@ -83,9 +82,8 @@ public class LnInvoiceViewHolder extends TransactionViewHolder {
     }
 
     @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals("firstCurrencyIsPrimary")) {
-            bindLnInvoiceItem(mLnInvoiceItem);
-        }
+    public void refreshViewHolder() {
+        bindLnInvoiceItem(mLnInvoiceItem);
+        super.refreshViewHolder();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnPaymentViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/LnPaymentViewHolder.java
@@ -1,6 +1,5 @@
 package zapsolutions.zap.transactionHistory.listItems;
 
-import android.content.SharedPreferences;
 import android.view.View;
 
 import com.github.lightningnetwork.lnd.lnrpc.Hop;
@@ -56,9 +55,8 @@ public class LnPaymentViewHolder extends TransactionViewHolder {
     }
 
     @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals("firstCurrencyIsPrimary")) {
-            bindLnPaymentItem(mLnPaymentItem);
-        }
+    public void refreshViewHolder() {
+        bindLnPaymentItem(mLnPaymentItem);
+        super.refreshViewHolder();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/OnChainTransactionViewHolder.java
+++ b/app/src/main/java/zapsolutions/zap/transactionHistory/listItems/OnChainTransactionViewHolder.java
@@ -1,6 +1,5 @@
 package zapsolutions.zap.transactionHistory.listItems;
 
-import android.content.SharedPreferences;
 import android.view.View;
 
 import zapsolutions.zap.R;
@@ -98,9 +97,8 @@ public class OnChainTransactionViewHolder extends TransactionViewHolder {
     }
 
     @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals("firstCurrencyIsPrimary")) {
-            bindOnChainTransactionItem(mOnChainTransactionItem);
-        }
+    public void refreshViewHolder() {
+        bindOnChainTransactionItem(mOnChainTransactionItem);
+        super.refreshViewHolder();
     }
 }

--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -812,8 +812,8 @@ public class Wallet {
 
             compositeDisposable.add(Observable.range(0, channelNodesList.size())
                     .concatMap(i -> Observable.just(i).delay(100, TimeUnit.MILLISECONDS))
-                    .doOnNext(integer -> fetchNodeInfoFromLND(channelNodesList.get(integer)))
-                    .doOnComplete(this::broadcastChannelsUpdated).subscribe());
+                    .doOnNext(integer -> fetchNodeInfoFromLND(channelNodesList.get(integer), integer == channelNodesList.size() - 1))
+                    .subscribe());
             return true;
         }).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(aBoolean -> {
             // Zip executed without error
@@ -835,7 +835,7 @@ public class Wallet {
      *
      * @param pubkey
      */
-    public void fetchNodeInfoFromLND(String pubkey) {
+    public void fetchNodeInfoFromLND(String pubkey, boolean broadcastChannelUpdate) {
         NodeInfoRequest nodeInfoRequest = NodeInfoRequest.newBuilder()
                 .setPubKey(pubkey)
                 .build();
@@ -845,6 +845,10 @@ public class Wallet {
                 .subscribe(nodeInfo -> {
                     ZapLog.v(LOG_TAG, "Fetched Node info from " + nodeInfo.getNode().getAlias());
                     mNodeInfos.add(nodeInfo);
+
+                    if (broadcastChannelUpdate) {
+                        broadcastChannelsUpdated();
+                    }
                 }, throwable -> ZapLog.w(LOG_TAG, "Exception in get node info (" + pubkey + ") request task: " + throwable.getMessage())));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Here is what is fixed / changed now:
- Racetime condition caused different data display on startup, as sometimes the transactions were displayed before the data to check if it is a channel event for example was available. Now when everything is available the outdated entries will get updated.
- Refreshing the list did not redraw the elements, therefore it was not possible to fix those outdated entries without scrolling them out of the view and then scrolling back.
Now refreshing the view by pulling down does what it should. It refreshes.
- Switching the currency while on the list caused some cached entries not to update leading to mixed currency display.
- Node or contact names were often not displayed as the data was available after the list was created.
- Simplified code 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The inconsistent display of data in the transaction history is very confusing for users.
So this PR should improve the UX a lot
Most likely fix #267 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My S9 on mainnet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.