### PR TITLE
Increased the timeout for LNURL Withdraw invoices

### DIFF
--- a/app/src/main/java/zapsolutions/zap/lnurl/withdraw/LnUrlWithdrawBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/lnurl/withdraw/LnUrlWithdrawBSDFragment.java
@@ -267,7 +267,7 @@ public class LnUrlWithdrawBSDFragment extends ZapBSDFragment {
                 Invoice asyncInvoiceRequest = Invoice.newBuilder()
                         .setValue(value)
                         .setMemo(mWithdrawData.getDefaultDescription())
-                        .setExpiry(60L) // in seconds
+                        .setExpiry(300L) // in seconds
                         .setPrivate(PrefsUtil.getPrefs().getBoolean("includePrivateChannelHints", true))
                         .build();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Increased the timeout from 1 min to 5 minutes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For some reason I had a "Invoice expired error" when using LNURL Withdraw with a service.
Maybe our clocks were not exactly in sync. Increasing it to 5 min solved the issue.
There aren't any really disadvantages to increasing this, so this should improve UX by causing less errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

My S9 claiming the bounty of bitcoin bounce game

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.