### PR TITLE
Fix endless spinner on channel refresh

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/Wallet.java
+++ b/app/src/main/java/zapsolutions/zap/util/Wallet.java
@@ -813,6 +813,11 @@ public class Wallet {
                     .concatMap(i -> Observable.just(i).delay(100, TimeUnit.MILLISECONDS))
                     .doOnNext(integer -> fetchNodeInfoFromLND(channelNodesList.get(integer), integer == channelNodesList.size() - 1))
                     .subscribe());
+
+            if (channelNodesList.size() == 0) {
+                broadcastChannelsUpdated();
+            }
+
             return true;
         }).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(aBoolean -> {
             // Zip executed without error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This bug was introduced with the history list fixes. UpdateChannels was no longer broadcasted if no new channel was added since the last update. Therefore the spinner was shown endlessly when doing a pull refresh.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making this thing bug free!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.