### PR TITLE
Update documentation, make clear Zap Android is for node operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Screenshot of Zap Android app](docs/screenshot.png)](https://zaphq.io/)
 
-Native android lightning wallet focused on user experience and ease of use ⚡️
+Native android lightning wallet for node operators focused on user experience and ease of use ⚡️
 
-Zap Android works as a remote control for one or more of your LND Nodes. Running LND in neutrino mode directly on the phone might be available later.
+Zap Android is not a classical wallet, it is actually a remote control for one or more of your LND Nodes. Zap Android aims to give node operators the opportunity to use their node in everyday situations with a simple and appealing user interface.
 
 The easiest way to get started is using [Umbrel](https://getumbrel.com/) to run LND on a raspberry pi and then connect Zap Android to that node.
 
@@ -23,8 +23,10 @@ The easiest way to get started is using [Umbrel](https://getumbrel.com/) to run 
 - [x] Transaction filter
 - [x] Read NFC tags
 - [x] [Avatars](https://github.com/michaelWuensch/avathor-rfc#avathor) 
+- [x] Bitcoin only
 
 **Security**
+- [x] Non-custodial
 - [x] PIN protected access
 - [x] Scrambled PIN by default
 - [x] Protection against screen recording
@@ -37,11 +39,14 @@ The easiest way to get started is using [Umbrel](https://getumbrel.com/) to run 
 - [x] Connect to remote Lnd node
 - [x] Connect to BTCPay Server
 - [x] Connect to lndconnect QR code
-- [ ] Run lnd on your android phone
 
 ## Security
 
 If you discover or learn about a potential error, weakness, or threat that can compromise the security of Zap, we ask you to keep it confidential and [submit your concern directly to the Zap security team](mailto:jimmymowschess@gmail.com?subject=[GitHub]%20Zap%20Security).
+
+## Non-custodial
+
+Zap Android is fully non-custodial. When using the app there is absolutely no interaction with any Zap team or service. We do not even know you are using our software.
 
 ## Get Help
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Zap Android can only be used to control LND nodes. This documentation change highlights this so users do not have false expectations.