### PR TITLE
Add specific zero-amount-payment-request error message

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/InvoiceUtil.java
@@ -204,7 +204,7 @@ public class InvoiceUtil {
                         listener.onError(ctx.getString(R.string.error_paymentRequestExpired), RefConstants.ERROR_DURATION_SHORT);
                     } else if (paymentRequest.getNumSatoshis() == 0) {
                         // Disable 0 sat invoices
-                        listener.onError(ctx.getString(R.string.error_notAPaymentRequest), RefConstants.ERROR_DURATION_LONG);
+                        listener.onError(ctx.getString(R.string.error_zeroAmountPaymentRequest), RefConstants.ERROR_DURATION_LONG);
                     } else {
                         listener.onValidLightningInvoice(paymentRequest, invoice);
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,7 @@
     <string name="error_blockExplorer_title">Block Explorer</string>
     <string name="error_blockExplorer_message" comment="Parameters are:  %1$s: Name of selected block explorer, %2$s: 'mainnet' or 'testnet'">"Your currently selected block explorer (%1$s) does not support %2$s. \nPlease go to settings and choose another block explorer to continue."</string>
     <string name="error_notAPaymentRequest">Invalid payment information.\n\nPlease use a Bitcoin address or Lightning payment request to initiate a payment.</string>
+    <string name="error_zeroAmountPaymentRequest">This is a zero amount payment request. Zap does not support zero amount payment requests due to security concerns associated with them.</string>
     <string name="error_paymentRequestExpired">This payment request expired.</string>
     <string name="error_useTestnetRequest">You are connected to TESTNET. Please use TESTNET addresses or payment requests.</string>
     <string name="error_useMainnetRequest">You are connected to MAINNET. Please use MAINNET addresses or payment requests.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,7 +270,6 @@
     <string name="error">Error</string>
     <string name="error_blockExplorer_title">Block Explorer</string>
     <string name="error_blockExplorer_message" comment="Parameters are:  %1$s: Name of selected block explorer, %2$s: 'mainnet' or 'testnet'">"Your currently selected block explorer (%1$s) does not support %2$s. \nPlease go to settings and choose another block explorer to continue."</string>
-    <string name="error_notAPaymentRequest">Invalid payment information.\n\nPlease use a Bitcoin address or Lightning payment request to initiate a payment.</string>
     <string name="error_zeroAmountPaymentRequest">This is a zero amount payment request. Zap does not support zero amount payment requests due to security concerns associated with them.</string>
     <string name="error_paymentRequestExpired">This payment request expired.</string>
     <string name="error_useTestnetRequest">You are connected to TESTNET. Please use TESTNET addresses or payment requests.</string>


### PR DESCRIPTION
## Description
This PR introduces a more specific error message for the error case where a payment requests has an invalid zero-amount attached to it.

The prior error message suggests a more general and broad failure of the payment request that is very difficult to understand and correct by the end-user.

_**Note:** The original error code was removed in a separate commit since it no longer is used anywhere else. If this isn't ok, we can simply drop that commit and force-push the branch (or revert the specific commit)_

## Motivation and Context
Issue:  #363 

## How Has This Been Tested?
Has not been tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.