### PR TITLE
Fix crash on lnurl channel

### DIFF
--- a/app/src/main/java/zapsolutions/zap/lnurl/channel/LnUrlChannelBSDFragment.java
+++ b/app/src/main/java/zapsolutions/zap/lnurl/channel/LnUrlChannelBSDFragment.java
@@ -235,8 +235,9 @@ public class LnUrlChannelBSDFragment extends ZapBSDFragment {
                     @Override
                     public void run() {
                         try {
-                            ZapLog.v(TAG, response.body().string());
-                            validateFinalResponse(response.body().string());
+                            String responseData = response.body().string();
+                            ZapLog.v(TAG, responseData);
+                            validateFinalResponse(responseData);
                         } catch (IOException e) {
                             e.printStackTrace();
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The lnurl channel flow crashed. The body().string() is empty in okhttp after accessing it once. Therefore it was empty.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing bugs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.