### PR TITLE
Caching node infos

### DIFF
--- a/app/src/main/java/zapsolutions/zap/util/PrefsUtil.java
+++ b/app/src/main/java/zapsolutions/zap/util/PrefsUtil.java
@@ -36,6 +36,7 @@ public class PrefsUtil {
     public static final String LAST_CLIPBOARD_SCAN = "lastClipboardScan";
     public static final String SCAN_CLIPBOARD = "scanClipboard";
     public static final String SHOW_IDENTITY_TAP_HINT = "identityTapHint";
+    public static final String NODE_INFO_CACHE = "nodeInfoCache";
 
     // wallet config preferences references
     public static final String WALLET_CONFIGS = "wallet_configs";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a cache of the nodes involved with your own node in regards to channels.
For nodes with large amounts of channels this drastically reduces the time needed until the aliases of the nodes appear.
The node also no further request node infos for closed channels which often resulted in an error message.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address #386 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.