### PR TITLE
Revert Target SDK to 30 to fix Android 12 problems

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'com.google.protobuf'
 import com.android.build.OutputFile
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 30
     defaultConfig {
         applicationId "zapsolutions.zap"
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 30
         versionCode 33
         versionName "0.5.3-beta"
         vectorDrawables.useSupportLibrary = true
@@ -203,7 +203,7 @@ dependencies {
 
 
     // Basic Android libraries
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR reverts the TargetSDK update from the last update.
There seem to be problems with Android 12 when this is enabled.

This is a fast temporary fix, the real fix can be delivered later, when the source of the problem is really found.

This addresses #396 