### PR TITLE
Remove on-chain address from transaction history details

### DIFF
--- a/app/src/main/res/layout/bsd_on_chain_transaction_detail.xml
+++ b/app/src/main/res/layout/bsd_on_chain_transaction_detail.xml
@@ -195,6 +195,7 @@
             android:layout_height="wrap_content"
             android:paddingTop="10dp"
             android:textSize="15sp"
+            android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/transactionID"
             tools:text="Address:" />
@@ -210,6 +211,7 @@
             android:textAlignment="viewEnd"
             android:textColor="@color/lightningOrange"
             android:textSize="15sp"
+            android:visibility="gone"
             app:layout_constraintEnd_toStartOf="@id/addressCopyIcon"
             app:layout_constraintStart_toEndOf="@id/addressLabel"
             app:layout_constraintTop_toBottomOf="@+id/transactionID"
@@ -221,6 +223,7 @@
             android:layout_height="20dp"
             android:background="@null"
             android:paddingStart="20dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/address"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/address"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the on-chain address from being displayed in the details for transaction in the transaction history.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address #406 
While most of the time this displayed the correct address, on some transactions that consisted of several outputs it showed the wrong address as it simply took the first one.
This can lead to confusion and in worst case to sending funds to wrong addresses.
The transaction ID is still displayed, so the transaction can be explored with a block explorer.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My S9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.