### PR TITLE
Add on-chain balance to wallet fragment

### DIFF
--- a/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
+++ b/app/src/main/java/zapsolutions/zap/fragments/WalletFragment.java
@@ -18,6 +18,7 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -55,10 +56,27 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
 
     private static final String LOG_TAG = WalletFragment.class.getName();
 
-    private TextView mTvPrimaryBalance;
-    private TextView mTvPrimaryBalanceUnit;
-    private TextView mTvSecondaryBalance;
-    private TextView mTvSecondaryBalanceUnit;
+    private LinearLayout mTotalBalancePrimaryLayout;
+    private TextView mTvTotalBalancePrimary;
+    private TextView mTvTotalBalancePrimaryUnit;
+    private LinearLayout mTotalBalanceSecondaryLayout;
+    private TextView mTvTotalBalanceSecondary;
+    private TextView mTvTotalBalanceSecondaryUnit;
+
+    private LinearLayout mChannelBalancePrimaryLayout;
+    private TextView mTvChannelBalancePrimary;
+    private TextView mTvChannelBalancePrimaryUnit;
+    private LinearLayout mChannelBalanceSecondaryLayout;
+    private TextView mTvChannelBalanceSecondary;
+    private TextView mTvChannelBalanceSecondaryUnit;
+
+    private LinearLayout mOnChainBalancePrimaryLayout;
+    private TextView mTvOnChainBalancePrimary;
+    private TextView mTvOnChainBalancePrimaryUnit;
+    private LinearLayout mOnChainBalanceSecondaryLayout;
+    private TextView mTvOnChainBalanceSecondary;
+    private TextView mTvOnChainBalanceSecondaryUnit;
+
     private TextView mTvMode;
     private ConstraintLayout mClBalanceLayout;
     private ImageView mIvLogo;
@@ -98,10 +116,28 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         mClBalanceLayout = view.findViewById(R.id.BalanceLayout);
         mIvLogo = view.findViewById(R.id.logo);
         mIvSwitchButton = view.findViewById(R.id.switchButtonImage);
-        mTvPrimaryBalance = view.findViewById(R.id.BalancePrimary);
-        mTvPrimaryBalanceUnit = view.findViewById(R.id.BalancePrimaryUnit);
-        mTvSecondaryBalance = view.findViewById(R.id.BalanceSecondary);
-        mTvSecondaryBalanceUnit = view.findViewById(R.id.BalanceSecondaryUnit);
+
+        mTotalBalancePrimaryLayout = view.findViewById(R.id.TotalBalancePrimaryLayout);
+        mTvTotalBalancePrimary = view.findViewById(R.id.TotalBalancePrimary);
+        mTvTotalBalancePrimaryUnit = view.findViewById(R.id.TotalBalancePrimaryUnit);
+        mTotalBalanceSecondaryLayout = view.findViewById(R.id.TotalBalanceSecondaryLayout);
+        mTvTotalBalanceSecondary = view.findViewById(R.id.TotalBalanceSecondary);
+        mTvTotalBalanceSecondaryUnit = view.findViewById(R.id.TotalBalanceSecondaryUnit);
+
+        mChannelBalancePrimaryLayout = view.findViewById(R.id.ChannelBalancePrimaryLayout);
+        mTvChannelBalancePrimary = view.findViewById(R.id.ChannelBalancePrimary);
+        mTvChannelBalancePrimaryUnit = view.findViewById(R.id.ChannelBalancePrimaryUnit);
+        mChannelBalanceSecondaryLayout = view.findViewById(R.id.ChannelBalanceSecondaryLayout);
+        mTvChannelBalanceSecondary = view.findViewById(R.id.ChannelBalanceSecondary);
+        mTvChannelBalanceSecondaryUnit = view.findViewById(R.id.ChannelBalanceSecondaryUnit);
+
+        mOnChainBalancePrimaryLayout = view.findViewById(R.id.OnChainBalancePrimaryLayout);
+        mTvOnChainBalancePrimary = view.findViewById(R.id.OnChainBalancePrimary);
+        mTvOnChainBalancePrimaryUnit = view.findViewById(R.id.OnChainBalancePrimaryUnit);
+        mOnChainBalanceSecondaryLayout = view.findViewById(R.id.OnChainBalanceSecondaryLayout);
+        mTvOnChainBalanceSecondary = view.findViewById(R.id.OnChainBalanceSecondary);
+        mTvOnChainBalanceSecondaryUnit = view.findViewById(R.id.OnChainBalanceSecondaryUnit);
+
         mTvMode = view.findViewById(R.id.mode);
         mBalanceFadeOutAnimation = AnimationUtils.loadAnimation(getActivity(), R.anim.balance_fade_out);
         mLogoFadeInAnimation = AnimationUtils.loadAnimation(getActivity(), R.anim.logo_fade_in);
@@ -167,6 +203,13 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         // Hide balance if the setting was chosen
         if (PrefsUtil.getPrefs().getBoolean("hideTotalBalance", false)) {
             hideBalance();
+        }
+
+        // Hide balance if the setting was chosen
+        if (PrefsUtil.getPrefs().getBoolean("detailedBalance", false)) {
+            showDetailedBalance();
+        } else {
+            showTotalBalance();
         }
 
         // Action when clicked on menu button
@@ -355,9 +398,13 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
             public void run() {
                 // Adapt unit text size depending on its length
                 if (MonetaryUtil.getInstance().getPrimaryDisplayUnit().length() > 2) {
-                    mTvPrimaryBalanceUnit.setTextSize(20);
+                    mTvTotalBalancePrimaryUnit.setTextSize(20);
+                    mTvChannelBalancePrimaryUnit.setTextSize(20);
+                    mTvOnChainBalancePrimaryUnit.setTextSize(20);
                 } else {
-                    mTvPrimaryBalanceUnit.setTextSize(32);
+                    mTvTotalBalancePrimaryUnit.setTextSize(32);
+                    mTvChannelBalancePrimaryUnit.setTextSize(32);
+                    mTvOnChainBalancePrimaryUnit.setTextSize(32);
                 }
 
                 Balances balances;
@@ -367,10 +414,20 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
                     balances = Wallet.getInstance().getDemoBalances();
                 }
 
-                mTvPrimaryBalance.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmount(balances.total()));
-                mTvPrimaryBalanceUnit.setText(MonetaryUtil.getInstance().getPrimaryDisplayUnit());
-                mTvSecondaryBalance.setText(MonetaryUtil.getInstance().getSecondaryDisplayAmount(balances.total()));
-                mTvSecondaryBalanceUnit.setText(MonetaryUtil.getInstance().getSecondaryDisplayUnit());
+                mTvTotalBalancePrimary.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmount(balances.total()));
+                mTvTotalBalancePrimaryUnit.setText(MonetaryUtil.getInstance().getPrimaryDisplayUnit());
+                mTvTotalBalanceSecondary.setText(MonetaryUtil.getInstance().getSecondaryDisplayAmount(balances.total()));
+                mTvTotalBalanceSecondaryUnit.setText(MonetaryUtil.getInstance().getSecondaryDisplayUnit());
+
+                mTvChannelBalancePrimary.setText("⚡ " + MonetaryUtil.getInstance().getPrimaryDisplayAmount(balances.channelTotal()));
+                mTvChannelBalancePrimaryUnit.setText(MonetaryUtil.getInstance().getPrimaryDisplayUnit());
+                mTvChannelBalanceSecondary.setText(MonetaryUtil.getInstance().getSecondaryDisplayAmount(balances.channelTotal()));
+                mTvChannelBalanceSecondaryUnit.setText(MonetaryUtil.getInstance().getSecondaryDisplayUnit());
+
+                mTvOnChainBalancePrimary.setText("❄ " + MonetaryUtil.getInstance().getPrimaryDisplayAmount(balances.onChainTotal()));
+                mTvOnChainBalancePrimaryUnit.setText(MonetaryUtil.getInstance().getPrimaryDisplayUnit());
+                mTvOnChainBalanceSecondary.setText(MonetaryUtil.getInstance().getSecondaryDisplayAmount(balances.onChainTotal()));
+                mTvOnChainBalanceSecondaryUnit.setText(MonetaryUtil.getInstance().getSecondaryDisplayUnit());
 
                 ZapLog.v(LOG_TAG, "Total balance display updated");
             }
@@ -389,6 +446,13 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
                     hideBalance();
                 } else {
                     showBalance();
+                }
+            }
+            if (key.equals("detailedBalance")) {
+                if (PrefsUtil.getPrefs().getBoolean("detailedBalance", false)) {
+                    showDetailedBalance();
+                } else {
+                    showTotalBalance();
                 }
             }
         }
@@ -549,6 +613,28 @@ public class WalletFragment extends Fragment implements SharedPreferences.OnShar
         mClBalanceLayout.setVisibility(View.VISIBLE);
         mIvSwitchButton.setVisibility(View.VISIBLE);
         mIvLogo.setVisibility(View.INVISIBLE);
+    }
+
+    private void showTotalBalance() {
+        mTotalBalancePrimaryLayout.setVisibility(View.VISIBLE);
+        mTotalBalanceSecondaryLayout.setVisibility(View.VISIBLE);
+
+        mChannelBalancePrimaryLayout.setVisibility(View.GONE);
+        mChannelBalanceSecondaryLayout.setVisibility(View.GONE);
+
+        mOnChainBalancePrimaryLayout.setVisibility(View.GONE);
+        mOnChainBalanceSecondaryLayout.setVisibility(View.GONE);
+    }
+
+    private void showDetailedBalance() {
+        mTotalBalancePrimaryLayout.setVisibility(View.GONE);
+        mTotalBalanceSecondaryLayout.setVisibility(View.GONE);
+
+        mChannelBalancePrimaryLayout.setVisibility(View.VISIBLE);
+        mChannelBalanceSecondaryLayout.setVisibility(View.VISIBLE);
+
+        mOnChainBalancePrimaryLayout.setVisibility(View.VISIBLE);
+        mOnChainBalanceSecondaryLayout.setVisibility(View.VISIBLE);
     }
 
     private void updateStatusDot(String walletAlias) {

--- a/app/src/main/java/zapsolutions/zap/util/Balances.java
+++ b/app/src/main/java/zapsolutions/zap/util/Balances.java
@@ -26,6 +26,10 @@ public class Balances {
         return mOnChainBalanceTotal + mChannelBalance + mChannelBalancePendingOpen + mChannelBalanceLimbo;
     }
 
+    public long channelTotal() {
+        return mChannelBalance + mChannelBalancePendingOpen + mChannelBalanceLimbo;
+    }
+
     public long onChainTotal() {
         return mOnChainBalanceTotal;
     }

--- a/app/src/main/res/layout/fragment_wallet.xml
+++ b/app/src/main/res/layout/fragment_wallet.xml
@@ -143,7 +143,7 @@
             app:layout_constraintVertical_bias="0.4">
 
             <LinearLayout
-                android:id="@+id/BalancePrimaryLayout"
+                android:id="@+id/TotalBalancePrimaryLayout"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginStart="8dp"
@@ -153,7 +153,7 @@
                 app:layout_constraintStart_toStartOf="parent">
 
                 <TextView
-                    android:id="@+id/BalancePrimary"
+                    android:id="@+id/TotalBalancePrimary"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textAlignment="center"
@@ -166,7 +166,7 @@
                     tools:text="Primary" />
 
                 <zapsolutions.zap.customView.NonClippingTextView
-                    android:id="@+id/BalancePrimaryUnit"
+                    android:id="@+id/TotalBalancePrimaryUnit"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
@@ -179,7 +179,7 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/BalanceSecondaryLayout"
+                android:id="@+id/TotalBalanceSecondaryLayout"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginStart="8dp"
@@ -187,20 +187,20 @@
                 android:orientation="horizontal"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/BalancePrimaryLayout">
+                app:layout_constraintTop_toBottomOf="@+id/TotalBalancePrimaryLayout">
 
                 <TextView
-                    android:id="@+id/BalanceSecondary"
+                    android:id="@+id/TotalBalanceSecondary"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textAlignment="center"
                     android:textColor="@color/gray"
                     android:textSize="15sp"
-                    app:layout_constraintTop_toBottomOf="@id/BalancePrimary"
+                    app:layout_constraintTop_toBottomOf="@id/TotalBalancePrimary"
                     tools:text="Secondary" />
 
                 <zapsolutions.zap.customView.NonClippingTextView
-                    android:id="@+id/BalanceSecondaryUnit"
+                    android:id="@+id/TotalBalanceSecondaryUnit"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="6dp"
@@ -211,6 +211,144 @@
                     tools:text="sat" />
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/ChannelBalancePrimaryLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent">
+
+                <TextView
+                    android:id="@+id/ChannelBalancePrimary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="38sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="Primary" />
+
+                <zapsolutions.zap.customView.NonClippingTextView
+                    android:id="@+id/ChannelBalancePrimaryUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="20sp"
+                    android:textStyle="italic"
+                    tools:text="BTC" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/ChannelBalanceSecondaryLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ChannelBalancePrimaryLayout">
+
+                <TextView
+                    android:id="@+id/ChannelBalanceSecondary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="15sp"
+                    app:layout_constraintTop_toBottomOf="@id/TotalBalancePrimary"
+                    tools:text="Secondary" />
+
+                <zapsolutions.zap.customView.NonClippingTextView
+                    android:id="@+id/ChannelBalanceSecondaryUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="15sp"
+                    android:textStyle="italic"
+                    tools:text="sat" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/OnChainBalancePrimaryLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="20pt"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ChannelBalanceSecondaryLayout">
+
+                <TextView
+                    android:id="@+id/OnChainBalancePrimary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="38sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="Primary" />
+
+                <zapsolutions.zap.customView.NonClippingTextView
+                    android:id="@+id/OnChainBalancePrimaryUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="20sp"
+                    android:textStyle="italic"
+                    tools:text="BTC" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/OnChainBalanceSecondaryLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/OnChainBalancePrimaryLayout">
+
+                <TextView
+                    android:id="@+id/OnChainBalanceSecondary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="15sp"
+                    app:layout_constraintTop_toBottomOf="@id/OnChainBalancePrimary"
+                    tools:text="Secondary" />
+
+                <zapsolutions.zap.customView.NonClippingTextView
+                    android:id="@+id/OnChainBalanceSecondaryUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="15sp"
+                    android:textStyle="italic"
+                    tools:text="sat" />
+            </LinearLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -282,7 +420,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/BalanceLayout"
             app:layout_constraintStart_toEndOf="@+id/BalanceLayout"
             app:layout_constraintTop_toTopOf="@+id/BalanceLayout"
-            app:layout_constraintVertical_bias="0.6"
+            app:layout_constraintVertical_bias="0.5"
             app:tint="@color/lightningOrange" />
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,7 @@
     <string name="settings_scan_clipboard">Check clipboard</string>
     <string name="settings_scan_clipboard_summary">Automatically check clipboard for data Zap can handle.</string>
     <string name="settings_hapticPin">Haptic PIN Feedback</string>
+    <string name="settings_detailedBalance" translatable="false">Detailed balance</string>
     <string name="settings_systemLanguage">System Language</string>
 
     <string name="settings_manageChannels">Manage Lightning Channels</string>
@@ -516,5 +517,6 @@
     <string name="backup_data_invalid_file_chosen">This is not a valid backup file. Please chose a file that was created with this app.</string>
 
     <string name="dialog_open_url">The data links to a webpage. Do you want to open the following webpage?\n\n%1$s</string>
+
 
 </resources>

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -41,6 +41,12 @@
             android:title="@string/settings_hapticPin"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="detailedBalance"
+            android:title="@string/settings_detailedBalance"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Add on-chain balance to wallet fragment

## Description
In the wallet home page, it shows the lightning balance and the on-chain balance.
The code is simply a suggestion, probably there are better ways to do it.
A problem is the position of switchButtonImage which now is a little bit ambiguous.

## Motivation and Context
You can easily see how much you can pay with lightning or with an on-chain transaction.

## How Has This Been Tested?
Tested on my phone Xiaomi Redmi Note 9 Pro

## Screenshots (if appropriate):
![screenshot](https://user-images.githubusercontent.com/6314653/195133288-6c803e2c-5239-4109-b928-feb0eb7f0992.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.